### PR TITLE
Configure unique_id() so entities can be edited in HA UI

### DIFF
--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -101,7 +101,7 @@ class WinixPurifier(FanEntity):
         """Initialize the device."""
         self._wrapper = wrapper
 
-        self._id = f"{DOMAIN}.{WINIX_DOMAIN}_{wrapper.info.mac.lower()}"
+        self._unique_id = f"{DOMAIN}.{WINIX_DOMAIN}_{wrapper.info.mac.lower()}"
         self._name = f"Winix {self._wrapper.info.alias}"
         self._state = None
 
@@ -131,9 +131,18 @@ class WinixPurifier(FanEntity):
         return attributes
 
     @property
-    def entity_id(self) -> str:
+    def unique_id(self) -> str:
         """Return the unique id of the switch."""
-        return self._id
+        return self._unique_id
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                (WINIX_DOMAIN, self._wrapper.info.mac.lower())
+            },
+            "name": self._name,
+        }
 
     @property
     def name(self) -> str:

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -32,7 +32,7 @@ class WinixPurifier(Entity):
         """Initialize the sensor."""
         self._wrapper = wrapper
 
-        self._id = f"{DOMAIN}.{WINIX_DOMAIN}_qvalue_{wrapper.info.mac.lower()}"
+        self._unique_id = f"{DOMAIN}.{WINIX_DOMAIN}_qvalue_{wrapper.info.mac.lower()}"
         self._name = f"Winix {self._wrapper.info.alias}"
         self._state = None
 
@@ -53,9 +53,18 @@ class WinixPurifier(Entity):
         return attributes
 
     @property
-    def entity_id(self) -> str:
+    def unique_id(self) -> str:
         """Return the unique id of the switch."""
-        return self._id
+        return self._unique_id
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                (WINIX_DOMAIN, self._wrapper.info.mac.lower())
+            },
+            "name": self._name,
+        }
 
     @property
     def icon(self):


### PR DESCRIPTION
Replace `entity_id` with `unique_id` so that the entities can be renamed and configured in the Home Assistant UI.

Additionally, add `device_info` in case this is ever migrated from using configuration.yaml for credentials (`async_setup_platform()`) to using config_flow (`async_setup_entry()`). This would allow a parent "device" to contain both sensor and fan entities.