### PR TITLE
Implement AQI Sensor

### DIFF
--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -19,6 +19,7 @@ ATTR_PLASMA: Final = "plasma"
 ATTR_POWER: Final = "power"
 ATTR_AIR_QUALITY: Final = "air_quality"
 ATTR_AIR_QVALUE: Final = "air_qvalue"
+ATTR_AIR_AQI: Final = "aqi"
 
 OFF_VALUE: Final = "off"
 ON_VALUE: Final = "on"

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -106,6 +106,8 @@ async def async_setup_entry(
 class WinixPurifier(WinixEntity, FanEntity):
     """Representation of a Winix Purifier entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, wrapper: WinixDeviceWrapper, coordinator: WinixManager) -> None:
         """Initialize the entity."""
         super().__init__(wrapper, coordinator)
@@ -115,6 +117,11 @@ class WinixPurifier(WinixEntity, FanEntity):
     def unique_id(self) -> str:
         """Return the unique id of the switch."""
         return self._unique_id
+
+    @property
+    def name(self) -> Union[str, None]:
+        """Entity Name (None, since this is the primary entity"""
+        return None
 
     @property
     def extra_state_attributes(self) -> Union[Mapping[str, Any], None]:

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any, Union
 
-from homeassistant.components.sensor import DOMAIN
+from homeassistant.components.sensor import DOMAIN, SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
@@ -44,7 +44,6 @@ class WinixSensor(WinixEntity, Entity):
     """Representation of a Winix Purifier air qValue sensor."""
 
     _attr_has_entity_name = True
-    _attr_name = "Air Quality"
     _attr_icon = ICON
 
     def __init__(self, wrapper: WinixDeviceWrapper, coordinator: WinixManager) -> None:
@@ -56,6 +55,11 @@ class WinixSensor(WinixEntity, Entity):
     def unique_id(self) -> str:
         """Return the unique id of the switch."""
         return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Entity name"""
+        return "Air Quality"
 
     @property
     def extra_state_attributes(self) -> Union[Mapping[str, Any], None]:
@@ -83,8 +87,6 @@ class WinixAqiSensor(WinixEntity, Entity):
     """Representation of a Winix Purifier air qValue sensor."""
 
     _attr_has_entity_name = True
-    _attr_name = "AQI"
-    _attr_icon = ICON
 
     def __init__(self, wrapper: WinixDeviceWrapper, coordinator: WinixManager) -> None:
         """Initialize the sensor."""
@@ -97,6 +99,11 @@ class WinixAqiSensor(WinixEntity, Entity):
         return self._unique_id
 
     @property
+    def name(self) -> str:
+        """Entity name"""
+        return "AQI"
+
+    @property
     def state(self) -> Union[str, None]:
         """Return the state of the sensor."""
         state = self._wrapper.get_state()
@@ -106,3 +113,8 @@ class WinixAqiSensor(WinixEntity, Entity):
     def unit_of_measurement(self) -> Union[str, None]:
         """Return the unit of measurement of this entity, if any."""
         return "AQI"
+
+    @property
+    def device_class(self) -> Union[str, None]:
+        """Return the device class of this entity"""
+        return SensorDeviceClass.AQI


### PR DESCRIPTION
My new Winix AM90 reports an "aqi" through the web API. This PR adds an HA sensor for the AQI, and updates the sensor naming to the latest standard, per https://developers.home-assistant.io/docs/core/entity#entity-naming . This means that the fan, existing Air Quality, and new AQI all have unique friendly names in the HA UI.

I'm not too familiar how to run the mypy or other integration checks here; if I've messed those up, let me know how to run them locally and I'll fix them.

Nice little integration, thank you!