### PR TITLE
Force plasma off in custom modes

### DIFF
--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -174,20 +174,20 @@ class WinixDeviceWrapper:
             self._logger.debug("%s: Setting auto mode", self._alias)
             await self._driver.auto()
 
-    async def async_plasmawave_on(self) -> None:
+    async def async_plasmawave_on(self, force: bool = False) -> None:
         """Turn on plasma wave."""
 
-        if not self._plasma_on:
+        if force or not self._plasma_on:
             self._plasma_on = True
             self._state[ATTR_PLASMA] = ON_VALUE
 
             self._logger.debug("%s: Turning plasmawave on", self._alias)
             await self._driver.plasmawave_on()
 
-    async def async_plasmawave_off(self) -> None:
+    async def async_plasmawave_off(self, force: bool = False) -> None:
         """Turn off plasma wave."""
 
-        if self._plasma_on:
+        if force or self._plasma_on:
             self._plasma_on = False
             self._state[ATTR_PLASMA] = OFF_VALUE
 
@@ -261,10 +261,10 @@ class WinixDeviceWrapper:
             await self.async_plasmawave_on()
         elif preset_mode == PRESET_MODE_AUTO_PLASMA_OFF:
             await self.async_auto()
-            await self.async_plasmawave_off()
+            await self.async_plasmawave_off(True)
         elif preset_mode == PRESET_MODE_MANUAL:
             await self.async_manual()
             await self.async_plasmawave_on()
         elif preset_mode == PRESET_MODE_MANUAL_PLASMA_OFF:
             await self.async_manual()
-            await self.async_plasmawave_off()
+            await self.async_plasmawave_off(True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, Mock
 
+from homeassistant import loader
 from homeassistant.components.sensor import SensorEntityDescription, SensorStateClass
 import pytest
 
@@ -61,3 +62,9 @@ def mock_driver_with_payload(request) -> WinixDriver:
 
     device_id = "device_1"
     yield WinixDriver(device_id, client)
+
+
+@pytest.fixture
+def enable_custom_integrations(hass):
+    """Enable custom integrations defined in the test dir."""
+    hass.data.pop(loader.DATA_CUSTOM_COMPONENTS)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,85 @@
+"""Test config flow."""
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.winix.const import WINIX_AUTH_RESPONSE, WINIX_DOMAIN
+from custom_components.winix.helpers import WinixException
+from winix import WinixAccount, auth
+
+TEST_USER_DATA = {
+    CONF_USERNAME: "user_name",
+    CONF_PASSWORD: "password",
+}
+
+LOGIN_AUTH_RESPONSE = {
+    "user_id": "test_userid",
+    "access_token": "AccessToken",
+    "refresh_token": "RefreshToken",
+    "id_token": "IdToken",
+}
+
+
+async def test_form(hass: HomeAssistant, enable_custom_integrations) -> None:
+    """Test that form shows up."""
+
+    result = await hass.config_entries.flow.async_init(
+        WINIX_DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["errors"] == {}
+
+
+async def test_invalid_user(hass: HomeAssistant, enable_custom_integrations) -> None:
+    """Test user validation in form."""
+
+    with patch(
+        "custom_components.winix.Helpers.async_login",
+        side_effect=WinixException(
+            {"result_code": "UserNotFoundException", "message": "User not found"}
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            WINIX_DOMAIN, context={"source": SOURCE_USER}, data=TEST_USER_DATA
+        )
+        assert result["errors"]["base"] == "invalid_user"
+        assert result["step_id"] == "user"
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+
+async def test_invalid_authentication(
+    hass: HomeAssistant, enable_custom_integrations
+) -> None:
+    """Test user authentication in form."""
+
+    with patch(
+        "custom_components.winix.Helpers.async_login",
+        side_effect=WinixException(
+            {"result_code": "failure", "message": "Authentication failed"}
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            WINIX_DOMAIN, context={"source": SOURCE_USER}, data=TEST_USER_DATA
+        )
+
+        assert result["errors"]["base"] == "invalid_auth"
+        assert result["step_id"] == "user"
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+
+async def test_create_entry(hass: HomeAssistant, enable_custom_integrations) -> None:
+    """Test that entry is created."""
+
+    with patch(
+        "custom_components.winix.Helpers.async_login",
+        side_effect=AsyncMock(return_value=LOGIN_AUTH_RESPONSE),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            WINIX_DOMAIN, context={"source": SOURCE_USER}, data=TEST_USER_DATA
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY


### PR DESCRIPTION
It seems that the device goes into some inconsistent state. Invoking auto command turns on plasma but the endpoint still says plasma is off. Forcing plasma=off does fix the issue so I am going with that.

#47