### PR TITLE
Handle missing filter life

### DIFF
--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -124,6 +124,10 @@ class WinixSensor(WinixEntity, SensorEntity):
             return state.get(ATTR_AIR_AQI)
 
         if self.entity_description.key == SENSOR_FILTER_LIFE:
+            value = state.get(ATTR_FILTER_HOUR)
+            if value is None:
+                return None
+
             hours: int = int(state.get(ATTR_FILTER_HOUR))
             if hours > TOTAL_FILTER_LIFE:
                 _LOGGER.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 from homeassistant import loader
 from homeassistant.components.sensor import SensorEntityDescription, SensorStateClass
+from homeassistant.const import PERCENTAGE
 import pytest
 
-from custom_components.winix.const import SENSOR_AIR_QVALUE
+from custom_components.winix.const import SENSOR_AIR_QVALUE, SENSOR_FILTER_LIFE
 from custom_components.winix.device_wrapper import WinixDeviceWrapper
 from custom_components.winix.driver import WinixDriver
 
@@ -29,13 +30,36 @@ def mock_device_wrapper() -> WinixDeviceWrapper:
 
 
 @pytest.fixture
-def mock_qvalue_description() -> SensorEntityDescription:
+def mock_sensor_description(sensor_key) -> SensorEntityDescription:
     """Return a mocked SensorEntityDescription instance."""
+
+    yield SensorEntityDescription(
+        key=sensor_key,
+        name="Test sensor description",
+        state_class=SensorStateClass.MEASUREMENT,
+    )
+
+
+@pytest.fixture
+def mock_qvalue_description() -> SensorEntityDescription:
+    """Return a mocked qValue SensorEntityDescription instance."""
 
     yield SensorEntityDescription(
         key=SENSOR_AIR_QVALUE,
         name="Air QValue",
         native_unit_of_measurement="qv",
+        state_class=SensorStateClass.MEASUREMENT,
+    )
+
+
+@pytest.fixture
+def mock_filter_life_description() -> SensorEntityDescription:
+    """Return a mocked SensorEntityDescription instance."""
+
+    yield SensorEntityDescription(
+        key=SENSOR_FILTER_LIFE,
+        name="Filter Life",
+        native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,15 +1,13 @@
 """Test config flow."""
 from unittest.mock import AsyncMock, patch
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import data_entry_flow
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
 
-from custom_components.winix.const import WINIX_AUTH_RESPONSE, WINIX_DOMAIN
+from custom_components.winix.const import WINIX_DOMAIN
 from custom_components.winix.helpers import WinixException
-from winix import WinixAccount, auth
 
 TEST_USER_DATA = {
     CONF_USERNAME: "user_name",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,14 +3,23 @@
 from unittest.mock import MagicMock, Mock
 
 from homeassistant.config_entries import ConfigEntry
+import pytest
 
 from custom_components.winix.const import (
+    ATTR_AIR_AQI,
     ATTR_AIR_QUALITY,
     ATTR_AIR_QVALUE,
+    ATTR_FILTER_HOUR,
+    SENSOR_AIR_QVALUE,
+    SENSOR_AQI,
     WINIX_DATA_COORDINATOR,
     WINIX_DOMAIN,
 )
-from custom_components.winix.sensor import WinixSensor, async_setup_entry
+from custom_components.winix.sensor import (
+    TOTAL_FILTER_LIFE,
+    WinixSensor,
+    async_setup_entry,
+)
 
 from tests import build_fake_manager
 
@@ -70,14 +79,45 @@ def test_sensor_attributes(mock_device_wrapper, mock_qvalue_description):
     assert sensor.extra_state_attributes[ATTR_AIR_QUALITY] == 12
 
 
-def test_sensor_native_value(mock_device_wrapper, mock_qvalue_description):
-    """Test sensor state."""
+@pytest.mark.parametrize(
+    "sensor_key, state_key, state_value, expected",
+    [
+        (SENSOR_AIR_QVALUE, ATTR_AIR_QVALUE, 100, 100),
+        (SENSOR_AQI, ATTR_AIR_AQI, 100, 100),
+    ],
+)
+def test_sensor_native_value(
+    state_key, state_value, expected, mock_sensor_description, mock_device_wrapper
+):
+    """Test sensor native state values."""
     mock_device_wrapper.get_state = MagicMock(return_value=None)
     coordinator = Mock()
 
-    sensor = WinixSensor(mock_device_wrapper, coordinator, mock_qvalue_description)
-
+    sensor = WinixSensor(mock_device_wrapper, coordinator, mock_sensor_description)
     assert sensor.state is None
 
-    mock_device_wrapper.get_state = MagicMock(return_value={ATTR_AIR_QVALUE: 100})
-    assert sensor.native_value == 100
+    mock_device_wrapper.get_state = MagicMock(return_value={state_key: state_value})
+    assert sensor.native_value == expected
+
+
+@pytest.mark.parametrize(
+    "filter_hour, expected",
+    [
+        (None, None),
+        (100, 98),  # 100 hour
+        (TOTAL_FILTER_LIFE + 1, None),  # Overbound filter life
+    ],
+)
+def test_filter_life_sensor_native_value(
+    filter_hour, expected, mock_device_wrapper, mock_filter_life_description
+):
+    """Test filter life sensor state."""
+    mock_device_wrapper.get_state = MagicMock(return_value=None)
+    coordinator = Mock()
+
+    sensor = WinixSensor(mock_device_wrapper, coordinator, mock_filter_life_description)
+
+    mock_device_wrapper.get_state = MagicMock(
+        return_value={} if filter_hour is None else {ATTR_FILTER_HOUR: filter_hour}
+    )
+    assert sensor.native_value == expected


### PR DESCRIPTION
This handles this crash

```
Traceback (most recent call last):
  File "/config/custom_components/winix/driver.py", line 190, in get_state
    payload = json["body"]["data"][0]["attributes"]
KeyError: 'body'
2023-03-04 07:08:21.462 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 182, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 330, in _async_refresh
    self.async_update_listeners()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 135, in async_update_listeners
    update_callback()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 390, in _handle_coordinator_update
    self.async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 559, in async_write_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 600, in _async_write_ha_state
    state = self._stringify_state(available)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 565, in _stringify_state
    if (state := self.state) is None:
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 470, in state
    value = self.native_value
  File "/config/custom_components/winix/sensor.py", line 127, in native_value
    hours: int = int(state.get(ATTR_FILTER_HOUR))
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```