### PR TITLE
Fix typo in setup process 

### DIFF
--- a/custom_components/winix/strings.json
+++ b/custom_components/winix/strings.json
@@ -6,8 +6,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         },
-        "description": "Set up Winix integration. Login with yout mobile app credentials.",
-        "title": "Winix Purifier"
+        "description": "Set up Winix integration. Login with your mobile app credentials.",
+        "title": "Winix Air Purifier"
       }
     },
     "error": {

--- a/custom_components/winix/translations/en.json
+++ b/custom_components/winix/translations/en.json
@@ -6,8 +6,8 @@
           "username": "Username",
           "password": "Password"
         },
-        "description": "Set up Winix integration. Login with yout mobile app credentials.",
-        "title": "Winix Purifier"
+        "description": "Set up Winix integration. Login with your mobile app credentials.",
+        "title": "Winix Air Purifier"
       }
     },
     "error": {


### PR DESCRIPTION
There's a typo in the setup process that tells the user `Login with yout mobile app credentials` fixed here. 

I also change the title of the prompt to make it clearer that this is an for air purifier.