### PR TITLE
Remove stale devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This can be installed by copying all the files from `custom_components/winix/` t
 
 ![image](https://user-images.githubusercontent.com/6459774/212468308-e6e855ac-ad26-4405-b683-246ccf4c8ccc.png)
 
-
 - The `Air QValue` sensor reports the qValue reported by Winix purifier. This value is related to air quality although I am not exactly sure what it represents.
 - The `AQI` sensor matches the led light on the purifier.
   - Good (Blue) = 1
@@ -23,9 +22,11 @@ This can be installed by copying all the files from `custom_components/winix/` t
 ![image](https://user-images.githubusercontent.com/6459774/212468432-0b37cd09-af5b-418c-855d-a12c8b21efc3.png)
 
 - The device data is fetched every 30 seconds.
-- There are 3 new services `winix.plasmawave_off, winix.plasmawave_on, plasmawave_toggle` in addition to the default fan services `fan.speed, fan.toggle, fan.turn_off, fan.turn_on, fan.set_preset_mode`.
+- There are 4 services `winix.plasmawave_off, winix.plasmawave_on, plasmawave_toggle and remove_stale_entities` in addition to the default fan services `fan.speed, fan.toggle, fan.turn_off, fan.turn_on, fan.set_preset_mode`.
+  - `remove_stale_entities` can be used to remove entities which appear unavaialble when the associated device is removed from the account.
 
 ## Note
+
 - If purifiers are added/removed, then you would want to restart HomeAssistant.
 
 - Winix **does not support** simultaneous login from multiple devices. If you logged into the mobile app after configuring HomeAssistant, then the HomeAssistant session gets flagged as invalid and vice-versa.

--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -104,12 +104,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                         "Unable to log in. Device access previously failed with `%s`",
                         str(err)
                     )
-                    raise ConfigEntryNotReady("Unable to authenticate.") from login_err
+                    raise ConfigEntryNotReady(
+                        "Unable to authenticate.") from login_err
             else:
                 try_prepare_devices_wrappers = False
 
                 # ConfigEntryNotReady will cause async_setup_entry to be invoked in background.
-                raise ConfigEntryNotReady("Unable to access device data.") from err
+                raise ConfigEntryNotReady(
+                    "Unable to access device data.") from err
 
     await manager.async_config_entry_first_refresh()
 

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -35,7 +35,7 @@ SERVICE_PLASMAWAVE_OFF: Final = "plasmawave_off"
 SERVICE_PLASMAWAVE_TOGGLE: Final = "plasmawave_toggle"
 SERVICE_REFRESH_ACCESS: Final = "refresh_access"
 SERVICE_REMOVE_STALE_ENTITIES: Final = "remove_stale_entities"
-SERVICES: Final = [
+FAN_SERVICES: Final = [
     SERVICE_PLASMAWAVE_ON,
     SERVICE_PLASMAWAVE_OFF,
     SERVICE_PLASMAWAVE_TOGGLE,

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -33,7 +33,6 @@ ON_VALUE: Final = "on"
 SERVICE_PLASMAWAVE_ON: Final = "plasmawave_on"
 SERVICE_PLASMAWAVE_OFF: Final = "plasmawave_off"
 SERVICE_PLASMAWAVE_TOGGLE: Final = "plasmawave_toggle"
-SERVICE_REFRESH_ACCESS: Final = "refresh_access"
 SERVICE_REMOVE_STALE_ENTITIES: Final = "remove_stale_entities"
 FAN_SERVICES: Final = [
     SERVICE_PLASMAWAVE_ON,

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -34,6 +34,7 @@ SERVICE_PLASMAWAVE_ON: Final = "plasmawave_on"
 SERVICE_PLASMAWAVE_OFF: Final = "plasmawave_off"
 SERVICE_PLASMAWAVE_TOGGLE: Final = "plasmawave_toggle"
 SERVICE_REFRESH_ACCESS: Final = "refresh_access"
+SERVICE_REMOVE_STALE_ENTITIES: Final = "remove_stale_entities"
 SERVICES: Final = [
     SERVICE_PLASMAWAVE_ON,
     SERVICE_PLASMAWAVE_OFF,

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -122,7 +122,8 @@ class WinixDriver:
     async def _rpc_attr(self, attr: str, value: str):
         _LOGGER.debug("_rpc_attr attribute=%s, value=%s", attr, value)
         resp = await self._client.get(
-            self.CTRL_URL.format(deviceid=self.device_id, attribute=attr, value=value),
+            self.CTRL_URL.format(deviceid=self.device_id,
+                                 attribute=attr, value=value),
             raise_for_status=True,
         )
         raw_resp = await resp.text()

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -81,7 +81,8 @@ async def async_setup_entry(
                 continue
 
             await getattr(device, method)(**params)
-            state_update_tasks.append(asyncio.create_task(device.async_update_ha_state(True)))
+            state_update_tasks.append(asyncio.create_task(
+                device.async_update_ha_state(True)))
 
         if state_update_tasks:
             # Update device states in HA
@@ -200,7 +201,8 @@ class WinixPurifier(WinixEntity, FanEntity):
             await self.async_turn_off()
         else:
             await self._wrapper.async_set_speed(
-                percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
+                percentage_to_ordered_list_item(
+                    ORDERED_NAMED_FAN_SPEEDS, percentage)
             )
 
         self.async_write_ha_state()

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -25,6 +25,7 @@ from .const import (
     ATTR_FILTER_REPLACEMENT_DATE,
     ATTR_LOCATION,
     ATTR_POWER,
+    FAN_SERVICES,
     ORDERED_NAMED_FAN_SPEEDS,
     PRESET_MODE_AUTO,
     PRESET_MODE_AUTO_PLASMA_OFF,
@@ -32,7 +33,6 @@ from .const import (
     PRESET_MODE_MANUAL_PLASMA_OFF,
     PRESET_MODE_SLEEP,
     PRESET_MODES,
-    SERVICES,
     WINIX_DATA_COORDINATOR,
     WINIX_DATA_KEY,
     WINIX_DOMAIN,
@@ -88,7 +88,7 @@ async def async_setup_entry(
             # Update device states in HA
             await asyncio.wait(state_update_tasks)
 
-    for service in SERVICES:
+    for service in FAN_SERVICES:
         hass.services.async_register(
             WINIX_DOMAIN,
             service,

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -136,12 +136,14 @@ class Helpers:
                 if result_code and result_message:
                     # pylint: disable=broad-exception-raised
                     raise Exception(
-                        f"Error while performing RPC get_device_info_list ({result_code}): {result_message}"
+                        f"Error while performing RPC get_device_info_list ({result_code}): {
+                            result_message}"
                     )
 
                 # pylint: disable=broad-exception-raised
                 raise Exception(
-                    f"Error while performing RPC get_device_info_list ({err_data.result_code}): {resp.text}"
+                    f"Error while performing RPC get_device_info_list ({err_data.result_code}): {
+                        resp.text}"
                 )
 
             return [

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -138,5 +138,6 @@ class WinixSensor(WinixEntity, SensorEntity):
 
             return int((TOTAL_FILTER_LIFE - hours) * 100 / TOTAL_FILTER_LIFE)
 
-        _LOGGER.error("Unhandled sensor '%s' encountered", self.entity_description.key)
+        _LOGGER.error("Unhandled sensor '%s' encountered",
+                      self.entity_description.key)
         return None

--- a/custom_components/winix/services.yaml
+++ b/custom_components/winix/services.yaml
@@ -23,3 +23,6 @@ plasmawave_toggle:
     entity_id:
       description: Name(s) of Winix entities. Leave service data empty to use all Winix entities.
       example: "fan.winix_living_room"
+
+remove_stale_entities:
+  description: Remove Winix entities with unavailable state and associated devices.

--- a/custom_components/winix/services.yaml
+++ b/custom_components/winix/services.yaml
@@ -1,8 +1,5 @@
 # Describes the format of available services.
 
-refresh_access:
-  description: Register the Cognito access token.
-
 plasmawave_on:
   description: Turn on plasmawave.
   fields:


### PR DESCRIPTION
This request introduces a service which can be used to cleanup stale Winix entities when the associated device is removed from the account. When a device is removed, the associated entities will starts appearing as `unavailable`.

Winix services are also now removed when all Winix devices are removed/disabled.