### PR TITLE
Handle authentication exceptions in better manner

### DIFF
--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -65,13 +65,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     if not auth_response:
-        Helpers.send_notification(
-            hass,
-            "async_setup_entry",
-            WINIX_NAME,
-            "No authentication data found. Please reconfigure the integration.",
+        raise ConfigEntryAuthFailed(
+            "No authentication data found. Please reconfigure the integration."
         )
-        return False
 
     manager = WinixManager(hass, entry, auth_response, DEFAULT_SCAN_INTERVAL)
     try_login_once = True

--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -132,11 +132,18 @@ def prepare_devices(
         # 900:MULTI LOGIN: Same credentials were used to login elwsewhere. We need to
         # login again and get new tokens.
         # 400:The user is not valid.
+
         if err.result_code in ("900", "400"):
+            LOGGER.info(
+                f"Failed to get device list (code={err.result_code}, message={err.result_message}), reauthenticating with stored credentials"
+            )
+
             try:
                 new_auth_response = Helpers.login(username, password)
             except WinixException as login_err:
                 raise ConfigEntryAuthFailed("Unable to authenticate.") from login_err
+
+            LOGGER.info("Reauthenticating successful, getting device list again")
 
             # Try preparing device wrappers again with new auth response
             try:

--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -140,7 +140,7 @@ def prepare_devices(
 
             # Try preparing device wrappers again with new auth response
             try:
-                manager.prepare_devices_wrappers()
+                manager.prepare_devices_wrappers(new_auth_response.access_token)
             except WinixException as err_retry:
                 raise ConfigEntryAuthFailed(
                     "Unable to access device data even after re-login."

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -101,7 +101,9 @@ class Helpers:
         return await hass.async_add_executor_job(_refresh, response)
 
     @staticmethod
-    def get_device_stubs(hass: HomeAssistant, access_token: str) -> None:
+    def get_device_stubs(
+        hass: HomeAssistant, access_token: str
+    ) -> list[MyWinixDeviceStub]:
         """Get device list.
 
         Raises WinixException.

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -101,67 +101,61 @@ class Helpers:
         return await hass.async_add_executor_job(_refresh, response)
 
     @staticmethod
-    async def async_get_device_stubs(hass: HomeAssistant, access_token: str) -> None:
+    def get_device_stubs(hass: HomeAssistant, access_token: str) -> None:
         """Get device list.
 
         Raises WinixException.
         """
 
         # Modified from https://github.com/hfern/winix to support additional attributes.
-        def get_device_info_list(access_token: str):
-            # pylint: disable=line-too-long
 
-            # com.google.gson.k kVar = new com.google.gson.k();
-            # kVar.p("accessToken", deviceMainActivity2.f2938o);
-            # kVar.p("uuid", Common.w(deviceMainActivity2.f2934k));
-            # new com.winix.smartiot.util.o0(deviceMainActivity2.f2934k, "https://us.mobile.winix-iot.com/getDeviceInfoList", kVar).a(new TypeToken<g4.v>() {
-            #  // from class: com.winix.smartiot.activity.DeviceMainActivity.9
-            # }, new com.winix.smartiot.activity.d(deviceMainActivity2, 4));
+        # com.google.gson.k kVar = new com.google.gson.k();
+        # kVar.p("accessToken", deviceMainActivity2.f2938o);
+        # kVar.p("uuid", Common.w(deviceMainActivity2.f2934k));
+        # new com.winix.smartiot.util.o0(deviceMainActivity2.f2934k, "https://us.mobile.winix-iot.com/getDeviceInfoList", kVar).a(new TypeToken<g4.v>() {
+        #  // from class: com.winix.smartiot.activity.DeviceMainActivity.9
+        # }, new com.winix.smartiot.activity.d(deviceMainActivity2, 4));
 
-            resp = requests.post(
-                "https://us.mobile.winix-iot.com/getDeviceInfoList",
-                json={
-                    "accessToken": access_token,
-                    "uuid": WinixAccount(access_token).get_uuid(),
-                },
-                timeout=DEFAULT_POST_TIMEOUT,
+        resp = requests.post(
+            "https://us.mobile.winix-iot.com/getDeviceInfoList",
+            json={
+                "accessToken": access_token,
+                "uuid": WinixAccount(access_token).get_uuid(),
+            },
+            timeout=DEFAULT_POST_TIMEOUT,
+        )
+
+        if resp.status_code != HTTPStatus.OK:
+            err_data = resp.json()
+            result_code = err_data.get("resultCode")
+            result_message = err_data.get("resultMessage")
+
+            LOGGER.error(
+                "Error obtaining device list %s:%s",
+                result_code,
+                result_message,
             )
 
-            if resp.status_code != HTTPStatus.OK:
-                err_data = resp.json()
-                result_code = err_data.get("resultCode")
-                result_message = err_data.get("resultMessage")
+            raise WinixException(
+                {
+                    "message": "Failed to get device list",
+                    "result_code": result_code,
+                    "result_message": result_message,
+                }
+            )
 
-                LOGGER.error(
-                    "Error obtaining device list %s:%s",
-                    result_code,
-                    result_message,
-                )
-
-                raise WinixException(
-                    {
-                        "message": "Failed to get device list",
-                        "result_code": result_code,
-                        "result_message": result_message,
-                    }
-                )
-
-            return [
-                MyWinixDeviceStub(
-                    id=d.get("deviceId"),
-                    mac=d.get("mac"),
-                    alias=d.get("deviceAlias"),
-                    location_code=d.get("deviceLocCode"),
-                    filter_replace_date=d.get("filterReplaceDate"),
-                    model=d.get("modelName"),
-                    sw_version=d.get("mcuVer"),
-                )
-                for d in resp.json()["deviceInfoList"]
-            ]
-
-        # Pass through all exceptions
-        LOGGER.debug("Obtaining device list")
-        return await hass.async_add_executor_job(get_device_info_list, access_token)
+        return [
+            MyWinixDeviceStub(
+                id=d.get("deviceId"),
+                mac=d.get("mac"),
+                alias=d.get("deviceAlias"),
+                location_code=d.get("deviceLocCode"),
+                filter_replace_date=d.get("filterReplaceDate"),
+                model=d.get("modelName"),
+                sw_version=d.get("mcuVer"),
+            )
+            for d in resp.json()["deviceInfoList"]
+        ]
 
 
 class WinixException(Exception):

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -130,12 +130,6 @@ class Helpers:
             result_code = err_data.get("resultCode")
             result_message = err_data.get("resultMessage")
 
-            LOGGER.error(
-                "Error obtaining device list %s:%s",
-                result_code,
-                result_message,
-            )
-
             raise WinixException(
                 {
                     "message": "Failed to get device list",

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -132,7 +132,7 @@ class Helpers:
 
             raise WinixException(
                 {
-                    "message": "Failed to get device list",
+                    "message": f"Failed to get device list (code-{result_code}). {result_message}.",
                     "result_code": result_code,
                     "result_message": result_message,
                 }

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -91,7 +91,7 @@ class WinixManager(DataUpdateCoordinator):
         """Fetch the latest data from the source. This overrides the method in DataUpdateCoordinator."""
         await self.async_update()
 
-    def prepare_devices_wrappers(self) -> None:
+    def prepare_devices_wrappers(self, access_token: str = "") -> None:
         """Prepare device wrappers.
 
         Raises WinixException.
@@ -100,7 +100,7 @@ class WinixManager(DataUpdateCoordinator):
         self._device_wrappers = []  # Reset device_stubs
 
         device_stubs = Helpers.get_device_stubs(
-            self.hass, self._auth_response.access_token
+            self.hass, access_token or self._auth_response.access_token
         )
 
         if device_stubs:

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -91,7 +91,7 @@ class WinixManager(DataUpdateCoordinator):
         """Fetch the latest data from the source. This overrides the method in DataUpdateCoordinator."""
         await self.async_update()
 
-    async def async_prepare_devices_wrappers(self) -> None:
+    def prepare_devices_wrappers(self) -> None:
         """Prepare device wrappers.
 
         Raises WinixException.
@@ -99,7 +99,7 @@ class WinixManager(DataUpdateCoordinator):
 
         self._device_wrappers = []  # Reset device_stubs
 
-        device_stubs = await Helpers.async_get_device_stubs(
+        device_stubs = Helpers.get_device_stubs(
             self.hass, self._auth_response.access_token
         )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,9 +7,10 @@ from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClien
 from voluptuous.validators import Number
 
 from custom_components.winix.const import WINIX_AUTH_RESPONSE, WINIX_DOMAIN
-from custom_components.winix.device_wrapper import WinixDeviceWrapper
+from custom_components.winix.device_wrapper import MyWinixDeviceStub, WinixDeviceWrapper
 from custom_components.winix.fan import WinixPurifier
 from custom_components.winix.manager import WinixManager
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
 TEST_DEVICE_ID = "847207352CE0_364yr8i989"
@@ -23,7 +24,9 @@ def config_entry(hass: HomeAssistant) -> MockConfigEntry:
             "access_token": "access_token",
             "refresh_token": "refresh_token",
             "id_token": "id_token",
-        }
+        },
+        CONF_USERNAME: "username",
+        CONF_PASSWORD: "password",
     }
 
     entry = MockConfigEntry(
@@ -34,24 +37,24 @@ def config_entry(hass: HomeAssistant) -> MockConfigEntry:
     return entry
 
 
-async def prepare_platform(
+async def init_integration(
     hass: HomeAssistant,
-    aioclient: AiohttpClientMocker,
-    test_device_stub,
-    test_device_json,
+    test_device_stub: MyWinixDeviceStub,
+    test_device_json: any,
+    aioclient_mock: AiohttpClientMocker,
 ) -> MockConfigEntry:
-    """Create a mock config entry."""
+    """Prepare the integration."""
 
     entry = config_entry(hass)
 
-    aioclient.get(
+    aioclient_mock.get(
         f"https://us.api.winix-iot.com/common/event/sttus/devices/{TEST_DEVICE_ID}",
         json=test_device_json,
     )
 
     with (
         patch(
-            "custom_components.winix.Helpers.async_get_device_stubs",
+            "custom_components.winix.Helpers.get_device_stubs",
             return_value=[test_device_stub],
         ),
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from .common import TEST_DEVICE_ID
 
 
 @pytest.fixture
-async def device_stub() -> any:
+async def device_stub() -> MyWinixDeviceStub:
     """Build mocked device stub."""
 
     return MyWinixDeviceStub(


### PR DESCRIPTION
Change in password or authentication failure will result in 400 or 900 code to be returned by Winix end point. We will try reauthentication once and then raise ConfigEntryAuthFailed which will cause HomeAssistant to present the option to enter new credentials.