### PR TITLE
Use aiohttp instead of requests 

### DIFF
--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -59,6 +59,8 @@ ORDERED_NAMED_FAN_SPEEDS: Final = [
     AIRFLOW_TURBO,
 ]
 
+DEFAULT_POST_TIMEOUT: Final = 5
+
 # mode can contain the special preset value of manual.
 MODE_AUTO: Final = "auto"
 MODE_MANUAL: Final = "manual"

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -32,9 +32,6 @@ class WinixDriver:
     CTRL_URL = "https://us.api.winix-iot.com/common/control/devices/{deviceid}/A211/{attribute}:{value}"
     STATE_URL = "https://us.api.winix-iot.com/common/event/sttus/devices/{deviceid}"
     PARAM_URL = "https://us.api.winix-iot.com/common/event/param/devices/{deviceid}"
-    CONNECTED_STATUS_URL = (
-        "https://us.api.winix-iot.com/common/event/connsttus/devices/{deviceid}"
-    )
 
     category_keys = {
         "power": "A02",

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -130,7 +130,7 @@ class WinixPurifier(WinixEntity, FanEntity):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return the state attributes."""
         attributes = {}
-        state = self._wrapper.get_state()
+        state = self.device_wrapper.get_state()
 
         if state is not None:
             # The power attribute is the entity state, so skip it
@@ -138,9 +138,9 @@ class WinixPurifier(WinixEntity, FanEntity):
                 key: value for key, value in state.items() if key != ATTR_POWER
             }
 
-        attributes[ATTR_LOCATION] = self._wrapper.device_stub.location_code
+        attributes[ATTR_LOCATION] = self.device_wrapper.device_stub.location_code
         attributes[ATTR_FILTER_REPLACEMENT_DATE] = (
-            self._wrapper.device_stub.filter_replace_date
+            self.device_wrapper.device_stub.filter_replace_date
         )
 
         return attributes
@@ -148,15 +148,15 @@ class WinixPurifier(WinixEntity, FanEntity):
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        return self._wrapper.is_on
+        return self.device_wrapper.is_on
 
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
-        state = self._wrapper.get_state()
+        state = self.device_wrapper.get_state()
         if state is None:
             return None
-        if self._wrapper.is_sleep or self._wrapper.is_auto:
+        if self.device_wrapper.is_sleep or self.device_wrapper.is_auto:
             return None
         if state.get(ATTR_AIRFLOW) is None:
             return None
@@ -168,21 +168,21 @@ class WinixPurifier(WinixEntity, FanEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite."""
-        state = self._wrapper.get_state()
+        state = self.device_wrapper.get_state()
         if state is None:
             return None
-        if self._wrapper.is_sleep:
+        if self.device_wrapper.is_sleep:
             return PRESET_MODE_SLEEP
-        if self._wrapper.is_auto:
+        if self.device_wrapper.is_auto:
             return (
                 PRESET_MODE_AUTO
-                if self._wrapper.is_plasma_on
+                if self.device_wrapper.is_plasma_on
                 else PRESET_MODE_AUTO_PLASMA_OFF
             )
-        if self._wrapper.is_manual:
+        if self.device_wrapper.is_manual:
             return (
                 PRESET_MODE_MANUAL
-                if self._wrapper.is_plasma_on
+                if self.device_wrapper.is_plasma_on
                 else PRESET_MODE_MANUAL_PLASMA_OFF
             )
 
@@ -208,7 +208,7 @@ class WinixPurifier(WinixEntity, FanEntity):
         if percentage == 0:
             await self.async_turn_off()
         else:
-            await self._wrapper.async_set_speed(
+            await self.device_wrapper.async_set_speed(
                 percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
             )
 
@@ -226,38 +226,38 @@ class WinixPurifier(WinixEntity, FanEntity):
         if percentage:
             await self.async_set_percentage(percentage)
         if preset_mode:
-            await self._wrapper.async_set_preset_mode(preset_mode)
+            await self.device_wrapper.async_set_preset_mode(preset_mode)
         else:
-            await self._wrapper.async_turn_on()
+            await self.device_wrapper.async_turn_on()
 
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the purifier."""
-        await self._wrapper.async_turn_off()
+        await self.device_wrapper.async_turn_off()
         self.async_write_ha_state()
 
     async def async_plasmawave_on(self) -> None:
         """Turn on plasma wave."""
-        await self._wrapper.async_plasmawave_on()
+        await self.device_wrapper.async_plasmawave_on()
         self.async_write_ha_state()
 
     async def async_plasmawave_off(self) -> None:
         """Turn off plasma wave."""
-        await self._wrapper.async_plasmawave_off()
+        await self.device_wrapper.async_plasmawave_off()
         self.async_write_ha_state()
 
     async def async_plasmawave_toggle(self) -> None:
         """Toggle plasma wave."""
 
-        if self._wrapper.is_plasma_on:
-            await self._wrapper.async_plasmawave_off()
+        if self.device_wrapper.is_plasma_on:
+            await self.device_wrapper.async_plasmawave_off()
         else:
-            await self._wrapper.async_plasmawave_on()
+            await self.device_wrapper.async_plasmawave_on()
 
         self.async_write_ha_state()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
-        await self._wrapper.async_set_preset_mode(preset_mode)
+        await self.device_wrapper.async_set_preset_mode(preset_mode)
         self.async_write_ha_state()

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -101,9 +101,7 @@ class Helpers:
         return await hass.async_add_executor_job(_refresh, response)
 
     @staticmethod
-    def get_device_stubs(
-        hass: HomeAssistant, access_token: str
-    ) -> list[MyWinixDeviceStub]:
+    def get_device_stubs(access_token: str) -> list[MyWinixDeviceStub]:
         """Get device list.
 
         Raises WinixException.

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -155,15 +155,20 @@ class Helpers:
 class WinixException(Exception):
     """Wiinx related operation exception."""
 
+    result_code: str = ""
+    """Error code."""
+    result_message: str = ""
+    """Error code message."""
+
     def __init__(self, values: dict) -> None:
         """Create instance of WinixException."""
 
-        super().__init__(values["message"])
-
-        self.result_code: str = values.get("result_code", "")
-        """Error code."""
-        self.result_message: str = values.get("result_message", "")
-        """Error code message."""
+        if values:
+            super().__init__(values.get("message", "Unknown error"))
+            self.result_code: str = values.get("result_code", "")
+            self.result_message: str = values.get("result_message", "")
+        else:
+            super().__init__("Unknown error")
 
     @staticmethod
     def from_winix_exception(err: Exception) -> WinixException:

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from winix import auth
+from winix import WinixAccount, auth
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -71,6 +70,7 @@ class WinixManager(DataUpdateCoordinator):
         entry: ConfigEntry,
         auth_response: auth.WinixAuthResponse,
         scan_interval: int,
+        client,
     ) -> None:
         """Initialize the manager."""
 
@@ -78,6 +78,7 @@ class WinixManager(DataUpdateCoordinator):
         # was not invoked.
         self._device_wrappers: list[WinixDeviceWrapper] = []
         self._auth_response = auth_response
+        self._client = client
 
         super().__init__(
             hass,
@@ -91,24 +92,21 @@ class WinixManager(DataUpdateCoordinator):
         """Fetch the latest data from the source. This overrides the method in DataUpdateCoordinator."""
         await self.async_update()
 
-    def prepare_devices_wrappers(self, access_token: str = "") -> None:
+    async def prepare_devices_wrappers(self, access_token: str = "") -> None:
         """Prepare device wrappers.
 
         Raises WinixException.
         """
-
         self._device_wrappers = []  # Reset device_stubs
 
-        device_stubs = Helpers.get_device_stubs(
-            access_token or self._auth_response.access_token
-        )
+        token = access_token or self._auth_response.access_token
+        uuid = WinixAccount(token).get_uuid()
+        device_stubs = await Helpers.get_device_stubs(self._client, token, uuid)
 
         if device_stubs:
-            client = aiohttp_client.async_get_clientsession(self.hass)
-
             for device_stub in device_stubs:
                 self._device_wrappers.append(
-                    WinixDeviceWrapper(client, device_stub, LOGGER)
+                    WinixDeviceWrapper(self._client, device_stub, LOGGER)
                 )
 
             LOGGER.info("%d purifiers found", len(self._device_wrappers))

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -100,7 +100,7 @@ class WinixManager(DataUpdateCoordinator):
         self._device_wrappers = []  # Reset device_stubs
 
         device_stubs = Helpers.get_device_stubs(
-            self.hass, access_token or self._auth_response.access_token
+            access_token or self._auth_response.access_token
         )
 
         if device_stubs:

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -45,7 +45,7 @@ class WinixEntity(CoordinatorEntity):
         device_stub = wrapper.device_stub
 
         self._mac = device_stub.mac.lower()
-        self._wrapper = wrapper
+        self.device_wrapper = wrapper
 
         self._attr_device_info: DeviceInfo = {
             "identifiers": {(WINIX_DOMAIN, self._mac)},
@@ -58,7 +58,7 @@ class WinixEntity(CoordinatorEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        state = self._wrapper.get_state()
+        state = self.device_wrapper.get_state()
         return state is not None
 
 

--- a/custom_components/winix/select.py
+++ b/custom_components/winix/select.py
@@ -104,9 +104,9 @@ class WinixSelectEntity(WinixEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the entity value."""
-        return self.entity_description.current_option_fn(self._wrapper)
+        return self.entity_description.current_option_fn(self.device_wrapper)
 
     async def async_select_option(self, option: str) -> None:
         """Set the entity value."""
-        if await self.entity_description.select_option_fn(self._wrapper, option):
+        if await self.entity_description.select_option_fn(self.device_wrapper, option):
             await self.coordinator.async_request_refresh()

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -152,7 +152,7 @@ class WinixSensor(WinixEntity, SensorEntity):
         if self.entity_description.extra_state_attributes_fn is None:
             return None
 
-        state = self._wrapper.get_state()
+        state = self.device_wrapper.get_state()
         return (
             None
             if state is None
@@ -162,5 +162,5 @@ class WinixSensor(WinixEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
-        state = self._wrapper.get_state()
+        state = self.device_wrapper.get_state()
         return None if state is None else self.entity_description.value_fn(state)

--- a/custom_components/winix/switch.py
+++ b/custom_components/winix/switch.py
@@ -83,14 +83,14 @@ class WinixSwitchEntity(WinixEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Return the switch state."""
-        return self.entity_description.is_on(self._wrapper)
+        return self.entity_description.is_on(self.device_wrapper)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        if await self.entity_description.off_fn(self._wrapper):
+        if await self.entity_description.off_fn(self.device_wrapper):
             self.schedule_update_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        if await self.entity_description.on_fn(self._wrapper):
+        if await self.entity_description.on_fn(self.device_wrapper):
             self.schedule_update_ha_state()

--- a/requirements_component.txt
+++ b/requirements_component.txt
@@ -1,2 +1,4 @@
 # Custom requirements
+python-jose[cryptography]==3.5.0
+pycryptodome==3.23.0
 winix==0.3.0

--- a/tests/common.py
+++ b/tests/common.py
@@ -57,6 +57,7 @@ async def init_integration(
             "custom_components.winix.Helpers.get_device_stubs",
             return_value=[test_device_stub],
         ),
+        patch("winix.WinixAccount.get_uuid"),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
This PR primarily uses  aiohttp instead of requests which required many functions to be made async.

An important fix as part of this was to avoid blocking event loop when reauthenticating due to multi-login.