### PR TITLE
fix: log login failure reason

### DIFF
--- a/custom_components/winix/config_flow.py
+++ b/custom_components/winix/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import WINIX_AUTH_RESPONSE, WINIX_DOMAIN, WINIX_NAME
+from .const import LOGGER, WINIX_AUTH_RESPONSE, WINIX_DOMAIN, WINIX_NAME
 from .helpers import Helpers, WinixException
 
 REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
@@ -41,6 +41,8 @@ class WinixFlowHandler(config_entries.ConfigFlow, domain=WINIX_DOMAIN):
         except WinixException as err:
             if err.result_code == "UserNotFoundException":
                 return {"errors": {"base": "invalid_user"}, WINIX_AUTH_RESPONSE: None}
+
+            LOGGER.error("Unexpected error during authentication: %s", err)
 
             return {
                 "errors": {"base": "invalid_auth"},


### PR DESCRIPTION
The standard dialog only displays the standard invalid credentials message and I have I have not found a way to dump the technical exception message there.

This PR logs the exception when validation fails as an error as a workaround.
