### PR TITLE
Add Dehumidifier Device Type Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,17 @@
 
 ## Summary
 
-A custom component to interact with Winix [C545](https://www.winixamerica.com/product/certified-refurbished-c545-air-purifier/) and [C610](https://www.winixamerica.com/product/c610/) air purifiers.
+A custom component to interact with Winix air purifiers and dehumidifiers.
 
-This has also been reported to work with these models: [AM90](https://www.winixamerica.com/product/am90/), [HR1000](https://www.amazon.com/Winix-HR1000-5-Stage-Enabled-Cleaner/dp/B01FWS0HSY), [C909](https://www.costco.com/winix-c909-4-stage-air-purifier-with-wi-fi-%2526-plasmawave-technology.product.100842491.html), [T800](https://winixeurope.eu/air-purifiers/winix-t800-wifi/), [T810](https://www.winixamerica.com/product/t810/),
- [5510](http://winixamerica.com/product/5510/), [5520](http://winixamerica.com/product/5520/), [9800](https://www.winixamerica.com/product/9800/). There could however be some difference in functionality.
+Air purifiers: confirmed on [C545](https://www.winixamerica.com/product/certified-refurbished-c545-air-purifier/) and [C610](https://www.winixamerica.com/product/c610/), and reported to work on [AM90](https://www.winixamerica.com/product/am90/), [HR1000](https://www.amazon.com/Winix-HR1000-5-Stage-Enabled-Cleaner/dp/B01FWS0HSY), [C909](https://www.costco.com/winix-c909-4-stage-air-purifier-with-wi-fi-%2526-plasmawave-technology.product.100842491.html), [T800](https://winixeurope.eu/air-purifiers/winix-t800-wifi/), [T810](https://www.winixamerica.com/product/t810/), [5510](http://winixamerica.com/product/5510/), [5520](http://winixamerica.com/product/5520/), [9800](https://www.winixamerica.com/product/9800/) — functionality may vary by model.
+
+Dehumidifiers: confirmed on [DXWE210](https://www.winix.com/product/1689) (Korean page). Other models in the `DXW*21*` family are likely compatible.
 
 ## Installation
 
 This can be installed by copying all the files from `custom_components/winix/` to `<config directory>/custom_components/winix/`. Next add Winix integration from `Add Integration` and use your credentials from Winix mobile app.
+
+### Air Purifier
 
 - C545 will generate 4 entities.
 - C610 will generate 6 entities.
@@ -31,6 +34,7 @@ This can be installed by copying all the files from `custom_components/winix/` t
 - The `PM 2.5` sensor is exposed only on devices that report particulate readings (e.g., T800).
 
 - The fan entity supports speed and preset modes
+- The `Child Lock` switch toggles the device's child lock, exposed only on devices that report support for the feature.
 
 ![image](https://user-images.githubusercontent.com/6459774/212468432-0b37cd09-af5b-418c-855d-a12c8b21efc3.png)
 
@@ -39,16 +43,35 @@ This can be installed by copying all the files from `custom_components/winix/` t
   - `remove_stale_entities` can be used to remove entities which appear unavaialble when the associated device is removed from the account.
 
 
-### Brightness Level
+#### Brightness Level
 If the purifiers support this feature, then you will see a selection list under the device.
 
 - Winix only supports updating the brightness level when the purifier is running.
 - The last brightness level is exposed as the attribute `last_brightness_level` on the fan.
 
 
+### Dehumidifier
+
+- DXWE210 will generate 7 entities.
+
+<img width="200" alt="dehumidifier_entities" src="https://github.com/user-attachments/assets/351e9887-8d8b-4ad7-a360-77662e991473" />
+
+- The `humidifier` entity is the primary control for the dehumidifier device.
+  - Powers the device on or off.
+    - Treats the `auto-dry` power state as off. It is represented by the `Auto Dry` binary sensor.
+  - Sets the operating mode: `Auto`, `Manual`, `Clothes`, `Shoes`, `Quiet`, or `Continuous`.
+  - Sets the target humidity, in the 35–70 % range with 5 % steps.
+  - Reports the current humidity from the device's sensor.
+- The `Fan Speed` select sets the fan to `low`, `high`, or `turbo`.
+- The `Auto Dry` binary sensor reflects the internal drying cycle, which runs while the device is powered off.
+- The `Water Tank` binary sensor reports a problem state when the tank is full or detached.
+- The `Timer` number entity sets an off-timer between 0 and 24 hours.
+- The `Child Lock` switch toggles the device's child lock, exposed only on devices that report support for the feature.
+- The `UV Sanitize` switch toggles UV sanitization, exposed only on devices that report support for the feature.
+
 ### Note
 
-- If purifiers are added/removed, then you would have to reload the integration.
+- If devices are added/removed, then you would have to reload the integration.
 
 - Winix **does not support** simultaneous login from multiple devices. If you logged into the mobile app after configuring HomeAssistant, then the HomeAssistant session gets flagged as invalid and vice-versa.
 

--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -39,7 +39,15 @@ from .manager import WinixManager
 
 type WinixConfigEntry = ConfigEntry[WinixManager]
 
-SUPPORTED_PLATFORMS = [Platform.FAN, Platform.SENSOR, Platform.SELECT, Platform.SWITCH]
+SUPPORTED_PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.FAN,
+    Platform.HUMIDIFIER,
+    Platform.NUMBER,
+    Platform.SENSOR,
+    Platform.SELECT,
+    Platform.SWITCH,
+]
 DEFAULT_SCAN_INTERVAL: Final = 30
 
 

--- a/custom_components/winix/binary_sensor.py
+++ b/custom_components/winix/binary_sensor.py
@@ -1,0 +1,86 @@
+"""Winix Binary Sensor."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WinixConfigEntry
+from .const import BINARY_SENSOR_AUTO_DRY, BINARY_SENSOR_WATER_TANK, LOGGER
+from .device_wrapper import WinixDeviceWrapper
+from .manager import WinixEntity, WinixManager
+
+
+@dataclass(frozen=True, kw_only=True)
+class WinixBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describe a Winix binary sensor entity."""
+
+    is_on: Callable[[WinixDeviceWrapper], bool]
+    exists_fn: Callable[[WinixDeviceWrapper], bool] = lambda _: True
+
+
+BINARY_SENSOR_DESCRIPTIONS: tuple[WinixBinarySensorEntityDescription, ...] = (
+    WinixBinarySensorEntityDescription(
+        key=BINARY_SENSOR_WATER_TANK,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        translation_key="water_tank",
+        is_on=lambda device: not device.is_water_tank_available,
+        exists_fn=lambda device: device.is_dehumidifier,
+    ),
+    WinixBinarySensorEntityDescription(
+        key=BINARY_SENSOR_AUTO_DRY,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        translation_key="auto_dry",
+        is_on=lambda device: device.is_auto_dry,
+        exists_fn=lambda device: device.is_dehumidifier,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WinixConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Winix binary sensors."""
+    manager = entry.runtime_data
+
+    entities = [
+        WinixBinarySensor(wrapper, manager, description)
+        for description in BINARY_SENSOR_DESCRIPTIONS
+        for wrapper in manager.get_device_wrappers()
+        if description.exists_fn(wrapper)
+    ]
+    async_add_entities(entities)
+    LOGGER.info("Added %s binary sensors", len(entities))
+
+
+class WinixBinarySensor(WinixEntity, BinarySensorEntity):
+    """Representation of a Winix binary sensor."""
+
+    entity_description: WinixBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        wrapper: WinixDeviceWrapper,
+        coordinator: WinixManager,
+        description: WinixBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(wrapper, coordinator)
+        self.entity_description = description
+
+        self._attr_unique_id = f"{description.key.lower()}_{self._mac}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the binary sensor is on."""
+        return self.entity_description.is_on(self.device_wrapper)

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -39,6 +39,9 @@ SENSOR_PM25: Final = "pm2_5"
 SENSOR_AQI: Final = "aqi"
 SENSOR_FILTER_LIFE: Final = "filter_life"
 
+BINARY_SENSOR_WATER_TANK: Final = "water_tank"
+BINARY_SENSOR_AUTO_DRY: Final = "auto_dry"
+
 OFF_VALUE: Final = "off"
 ON_VALUE: Final = "on"
 AUTO_DRY_VALUE: Final = "auto-dry"
@@ -73,6 +76,16 @@ ORDERED_NAMED_FAN_SPEEDS: Final = [
     AIRFLOW_TURBO,
 ]
 
+DEHUMIDIFIER_FAN_SPEEDS: Final = [
+    AIRFLOW_LOW,
+    AIRFLOW_HIGH,
+    AIRFLOW_TURBO,
+]
+
+DEHUMIDIFIER_MIN_HUMIDITY: Final = 35
+DEHUMIDIFIER_MAX_HUMIDITY: Final = 70
+DEHUMIDIFIER_HUMIDITY_STEP: Final = 5
+
 DEFAULT_FILTER_ALARM_DURATION: Final = 9  # 9 months
 DEFAULT_FILTER_ALARM_DURATION_HOURS: Final = DEFAULT_FILTER_ALARM_DURATION * 24 * 30
 DEFAULT_POST_TIMEOUT: Final = 5
@@ -84,6 +97,15 @@ MODE_CLOTHES: Final = "clothes"
 MODE_SHOES: Final = "shoes"
 MODE_QUIET: Final = "quiet"
 MODE_CONTINUOUS: Final = "continuous"
+
+DEHUMIDIFIER_MODES: Final = [
+    MODE_AUTO,
+    MODE_MANUAL,
+    MODE_CLOTHES,
+    MODE_SHOES,
+    MODE_QUIET,
+    MODE_CONTINUOUS,
+]
 
 PRESET_MODE_AUTO: Final = "Auto"
 PRESET_MODE_AUTO_PLASMA_OFF: Final = "Auto (PlasmaWave off)"

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -109,6 +109,8 @@ class WinixPurifier(WinixEntity, FanEntity):
     def __init__(self, wrapper: WinixDeviceWrapper, coordinator: WinixManager) -> None:
         """Initialize the entity."""
         super().__init__(wrapper, coordinator)
+        # Legacy format retained for existing installations; new entity types
+        # should use f"<key>_{self._mac}" without the platform/winix prefix.
         self._attr_unique_id = ENTITY_ID_FORMAT.format(f"{WINIX_DOMAIN}_{self._mac}")
 
     @property

--- a/custom_components/winix/humidifier.py
+++ b/custom_components/winix/humidifier.py
@@ -1,0 +1,135 @@
+"""Winix Dehumidifier entity."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.humidifier import (
+    HumidifierAction,
+    HumidifierEntity,
+    HumidifierEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WinixConfigEntry
+from .const import (
+    ATTR_CURRENT_HUMIDITY,
+    ATTR_MODE,
+    ATTR_TARGET_HUMIDITY,
+    DEHUMIDIFIER_HUMIDITY_STEP,
+    DEHUMIDIFIER_MAX_HUMIDITY,
+    DEHUMIDIFIER_MIN_HUMIDITY,
+    DEHUMIDIFIER_MODES,
+    LOGGER,
+)
+from .device_wrapper import WinixDeviceWrapper
+from .manager import WinixEntity, WinixManager
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WinixConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Winix dehumidifier entities."""
+    manager = entry.runtime_data
+    entities = [
+        WinixDehumidifier(wrapper, manager)
+        for wrapper in manager.get_device_wrappers()
+        if wrapper.is_dehumidifier
+    ]
+    async_add_entities(entities)
+    LOGGER.info("Added %s dehumidifiers", len(entities))
+
+
+class WinixDehumidifier(WinixEntity, HumidifierEntity):
+    """Representation of a Winix Dehumidifier."""
+
+    # https://developers.home-assistant.io/docs/core/entity/humidifier/
+    _attr_supported_features = HumidifierEntityFeature.MODES
+
+    _attr_min_humidity = DEHUMIDIFIER_MIN_HUMIDITY
+    _attr_max_humidity = DEHUMIDIFIER_MAX_HUMIDITY
+    _attr_target_humidity_step = DEHUMIDIFIER_HUMIDITY_STEP
+
+    _attr_translation_key = "dehumidifier"
+
+    def __init__(self, wrapper: WinixDeviceWrapper, coordinator: WinixManager) -> None:
+        """Initialize the dehumidifier entity."""
+        super().__init__(wrapper, coordinator)
+        self._attr_unique_id = f"dehumidifier_{self._mac}"
+
+    @property
+    def name(self) -> str | None:
+        """Return None so this is treated as the primary device entity."""
+        return None
+
+    @property
+    def available_modes(self) -> list[str]:
+        """Return the list of available modes."""
+        return DEHUMIDIFIER_MODES
+
+    @property
+    def mode(self) -> str | None:
+        """Return the current operating mode."""
+        state = self.device_wrapper.get_state()
+        if state is None:
+            return None
+        return state.get(ATTR_MODE)
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the dehumidifier is powered on."""
+        return self.device_wrapper.is_on
+
+    @property
+    def action(self) -> HumidifierAction | None:
+        """Return the current action."""
+        if self.device_wrapper.get_state() is None:
+            return None
+        if self.device_wrapper.is_on:
+            return HumidifierAction.DRYING
+        return HumidifierAction.OFF
+
+    @property
+    def current_humidity(self) -> int | None:
+        """Return the current humidity."""
+        state = self.device_wrapper.get_state()
+        if state is None:
+            return None
+        value = state.get(ATTR_CURRENT_HUMIDITY)
+        return int(value) if value is not None else None
+
+    @property
+    def target_humidity(self) -> int | None:
+        """Return the target humidity."""
+        state = self.device_wrapper.get_state()
+        if state is None:
+            return None
+        value = state.get(ATTR_TARGET_HUMIDITY)
+        return int(value) if value is not None else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the dehumidifier on."""
+        await self.device_wrapper.async_turn_on()
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the dehumidifier off."""
+        await self.device_wrapper.async_turn_off()
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_humidity(self, humidity: int) -> None:
+        """Set target humidity, rounding to nearest 5 % step and clamping to valid range."""
+        humidity = round(humidity / DEHUMIDIFIER_HUMIDITY_STEP) * DEHUMIDIFIER_HUMIDITY_STEP
+        humidity = max(DEHUMIDIFIER_MIN_HUMIDITY, min(DEHUMIDIFIER_MAX_HUMIDITY, humidity))
+        await self.device_wrapper.async_set_humidity(humidity)
+        self.async_write_ha_state()
+
+    async def async_set_mode(self, mode: str) -> None:
+        """Set operating mode. Wrapper validates against driver-supported modes."""
+        await self.device_wrapper.async_set_mode(mode)
+        self.async_write_ha_state()

--- a/custom_components/winix/icons.json
+++ b/custom_components/winix/icons.json
@@ -7,6 +7,36 @@
 					"off": "mdi:air-purifier-off"
 				}
 			}
+		},
+		"humidifier": {
+			"dehumidifier": {
+				"default": "mdi:air-humidifier",
+				"state": {
+					"off": "mdi:air-humidifier-off"
+				}
+			}
+		},
+		"binary_sensor": {
+			"water_tank": {
+				"default": "mdi:water-outline",
+				"state": {
+					"on": "mdi:water-alert"
+				}
+			},
+			"auto_dry": {
+				"default": "mdi:auto-mode",
+				"state": {
+					"on": "mdi:autorenew"
+				}
+			}
+		},
+		"switch": {
+			"uv_sanitize": {
+				"default": "mdi:white-balance-sunny",
+				"state": {
+					"off": "mdi:weather-sunny-off"
+				}
+			}
 		}
 	}
 }

--- a/custom_components/winix/number.py
+++ b/custom_components/winix/number.py
@@ -1,0 +1,92 @@
+"""Winix number entities (e.g. dehumidifier timer)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import WinixConfigEntry
+from .const import ATTR_TIMER, LOGGER
+from .device_wrapper import WinixDeviceWrapper
+from .manager import WinixEntity, WinixManager
+
+
+@dataclass(frozen=True, kw_only=True)
+class WinixNumberEntityDescription(NumberEntityDescription):
+    """Describe a Winix number entity."""
+
+    exists_fn: Callable[[WinixDeviceWrapper], bool]
+    value_fn: Callable[[WinixDeviceWrapper], float | None]
+    set_value_fn: Callable[[WinixDeviceWrapper, float], Coroutine[Any, Any, None]]
+
+
+NUMBER_DESCRIPTIONS: tuple[WinixNumberEntityDescription, ...] = (
+    WinixNumberEntityDescription(
+        key="timer",
+        translation_key="timer",
+        icon="mdi:timer-outline",
+        native_min_value=0,
+        native_max_value=24,
+        native_step=1,
+        mode=NumberMode.BOX,
+        native_unit_of_measurement="h",
+        exists_fn=lambda device: device.is_dehumidifier,
+        value_fn=lambda device: (device.get_state() or {}).get(ATTR_TIMER),
+        set_value_fn=lambda device, value: device.async_set_timer(round(value)),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WinixConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Winix number entities."""
+    manager = entry.runtime_data
+
+    entities = [
+        WinixNumberEntity(wrapper, manager, description)
+        for description in NUMBER_DESCRIPTIONS
+        for wrapper in manager.get_device_wrappers()
+        if description.exists_fn(wrapper)
+    ]
+    async_add_entities(entities)
+    LOGGER.info("Added %s number entities", len(entities))
+
+
+class WinixNumberEntity(WinixEntity, NumberEntity):
+    """Winix number entity (e.g. timer)."""
+
+    entity_description: WinixNumberEntityDescription
+
+    def __init__(
+        self,
+        wrapper: WinixDeviceWrapper,
+        coordinator: WinixManager,
+        description: WinixNumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(wrapper, coordinator)
+        self.entity_description = description
+
+        self._attr_unique_id = f"{description.key.lower()}_{self._mac}"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        return self.entity_description.value_fn(self.device_wrapper)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value."""
+        await self.entity_description.set_value_fn(self.device_wrapper, value)
+        self.async_write_ha_state()

--- a/custom_components/winix/select.py
+++ b/custom_components/winix/select.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import WINIX_DOMAIN, WinixConfigEntry
-from .const import LOGGER
+from .const import ATTR_AIRFLOW, DEHUMIDIFIER_FAN_SPEEDS, LOGGER
 from .device_wrapper import WinixDeviceWrapper
 from .driver import BrightnessLevel
 from .manager import WinixEntity, WinixManager
@@ -60,6 +60,15 @@ SELECT_DESCRIPTIONS: Final[tuple[WinixSelectEntityDescription, ...]] = (
         ),
         available_fn=lambda device: device.is_on,
     ),
+    WinixSelectEntityDescription(
+        current_option_fn=lambda device: (device.get_state() or {}).get(ATTR_AIRFLOW),
+        exists_fn=lambda device: device.is_dehumidifier,
+        icon="mdi:fan",
+        key="fan_speed",
+        name="Fan Speed",
+        options=DEHUMIDIFIER_FAN_SPEEDS,
+        select_option_fn=lambda device, value: device.async_set_speed(value),
+    ),
 )
 
 
@@ -97,6 +106,8 @@ class WinixSelectEntity(WinixEntity, SelectEntity):
         super().__init__(wrapper, coordinator)
         self.entity_description = description
 
+        # Legacy format retained for existing installations; new entity types
+        # should use f"<key>_{self._mac}" without the platform/winix prefix.
         self._attr_unique_id = ENTITY_ID_FORMAT.format(
             f"{WINIX_DOMAIN}_{description.key.lower()}_{self._mac}"
         )

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -158,6 +158,8 @@ class WinixSensor(WinixEntity, SensorEntity):
         super().__init__(wrapper, coordinator)
         self.entity_description = description
 
+        # Legacy format retained for existing installations; new entity types
+        # should use f"<key>_{self._mac}" without the platform/winix prefix.
         self._attr_unique_id = ENTITY_ID_FORMAT.format(
             f"{WINIX_DOMAIN}_{description.key.lower()}_{self._mac}"
         )

--- a/custom_components/winix/switch.py
+++ b/custom_components/winix/switch.py
@@ -37,6 +37,14 @@ SWITCH_DESCRIPTIONS: Final[tuple[WinixSwitchEntityDescription, ...]] = (
         on_fn=lambda device: device.async_child_lock_on(),
         off_fn=lambda device: device.async_child_lock_off(),
     ),
+    WinixSwitchEntityDescription(
+        key="uv_sanitize",
+        is_on=lambda device: device.is_uv_sanitize_on,
+        exists_fn=lambda device: device.features.supports_uv_sanitize,
+        name="UV Sanitize",
+        on_fn=lambda device: device.async_uv_sanitize_on(),
+        off_fn=lambda device: device.async_uv_sanitize_off(),
+    ),
 )
 
 
@@ -74,6 +82,8 @@ class WinixSwitchEntity(WinixEntity, SwitchEntity):
         super().__init__(wrapper, coordinator)
         self.entity_description = description
 
+        # Legacy format retained for existing installations; new entity types
+        # should use f"<key>_{self._mac}" without the platform/winix prefix.
         self._attr_unique_id = ENTITY_ID_FORMAT.format(
             f"{WINIX_DOMAIN}_{description.key.lower()}_{self._mac}"
         )

--- a/custom_components/winix/translations/en.json
+++ b/custom_components/winix/translations/en.json
@@ -15,5 +15,36 @@
       "invalid_user": "The username is invalid. Make sure it's the same one registered with the mobile app and that the capitalization matches.",
       "unknown": "Unexpected error"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "water_tank": {
+        "name": "Water Tank"
+      },
+      "auto_dry": {
+        "name": "Auto Dry"
+      }
+    },
+    "humidifier": {
+      "dehumidifier": {
+        "state_attributes": {
+          "mode": {
+            "state": {
+              "auto": "Auto",
+              "manual": "Manual",
+              "clothes": "Clothes",
+              "shoes": "Shoes",
+              "quiet": "Quiet",
+              "continuous": "Continuous"
+            }
+          }
+        }
+      }
+    },
+    "number": {
+      "timer": {
+        "name": "Timer"
+      }
+    }
   }
 }

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,174 @@
+"""Tests for Winix Binary Sensor entities (dehumidifier water tank, auto-dry)."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.winix.binary_sensor import (
+    BINARY_SENSOR_DESCRIPTIONS,
+    WinixBinarySensor,
+    async_setup_entry,
+)
+from custom_components.winix.const import (
+    BINARY_SENSOR_AUTO_DRY,
+    BINARY_SENSOR_WATER_TANK,
+    WINIX_DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+
+# Description lookup by key — robust to ordering changes.
+_DESC_BY_KEY = {d.key: d for d in BINARY_SENSOR_DESCRIPTIONS}
+WATER_TANK_DESC = _DESC_BY_KEY[BINARY_SENSOR_WATER_TANK]
+AUTO_DRY_DESC = _DESC_BY_KEY[BINARY_SENSOR_AUTO_DRY]
+
+# Number of binary sensors created per dehumidifier wrapper.
+PER_DEHUMIDIFIER = len(BINARY_SENSOR_DESCRIPTIONS)
+
+
+def _mock_dehumidifier_wrapper(index: int = 0) -> MagicMock:
+    """Return a MagicMock device_wrapper configured as a dehumidifier."""
+    wrapper = MagicMock()
+    wrapper.device_stub.mac = f"aabbccddee{index:02x}"
+    wrapper.device_stub.alias = f"Dehumidifier{index}"
+    wrapper.device_stub.model = "modelX"
+    wrapper.device_stub.sw_version = "1.0"
+    wrapper.is_dehumidifier = True
+    return wrapper
+
+
+def _mock_purifier_wrapper() -> MagicMock:
+    """Return a MagicMock device_wrapper configured as an air purifier."""
+    wrapper = MagicMock()
+    wrapper.is_dehumidifier = False
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_platform_adds_sensors_for_dehumidifiers(
+    hass: HomeAssistant,
+) -> None:
+    """All description-defined sensors are created for dehumidifier wrappers only."""
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[_mock_dehumidifier_wrapper(0), _mock_purifier_wrapper()]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id1")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    assert async_add_entities.called
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == PER_DEHUMIDIFIER
+    keys = {e.entity_description.key for e in entities}
+    assert keys == {BINARY_SENSOR_WATER_TANK, BINARY_SENSOR_AUTO_DRY}
+    assert all(isinstance(e, WinixBinarySensor) for e in entities)
+
+
+async def test_setup_platform_multiple_dehumidifiers(hass: HomeAssistant) -> None:
+    """Each dehumidifier gets the full set of binary sensors."""
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[_mock_dehumidifier_wrapper(0), _mock_dehumidifier_wrapper(1)]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id2")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == PER_DEHUMIDIFIER * 2
+
+
+async def test_setup_platform_no_dehumidifiers(hass: HomeAssistant) -> None:
+    """No binary sensors are added when there are no dehumidifiers."""
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[_mock_purifier_wrapper(), _mock_purifier_wrapper()]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id3")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 0
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "description",
+    [WATER_TANK_DESC, AUTO_DRY_DESC],
+    ids=["water_tank", "auto_dry"],
+)
+def test_construction(description) -> None:
+    """unique_id includes the description key; entity_description is set."""
+    wrapper = _mock_dehumidifier_wrapper()
+
+    sensor = WinixBinarySensor(wrapper, Mock(), description)
+
+    assert sensor.unique_id is not None
+    assert description.key in sensor.unique_id
+    assert sensor.entity_description is description
+
+
+# ---------------------------------------------------------------------------
+# water_tank.is_on (full/detached = problem)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("is_water_tank_available", "expected_is_on"),
+    [
+        (True, False),   # tank available (not full, not detached) -> no problem
+        (False, True),   # tank full or detached -> problem reported
+    ],
+)
+def test_water_tank_is_on(is_water_tank_available: bool, expected_is_on: bool) -> None:
+    """is_on is True when the water tank is full or detached (not available)."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.is_water_tank_available = is_water_tank_available
+
+    sensor = WinixBinarySensor(wrapper, Mock(), WATER_TANK_DESC)
+
+    assert sensor.is_on == expected_is_on
+
+
+# ---------------------------------------------------------------------------
+# auto_dry.is_on (running / not running)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("is_auto_dry", "expected_is_on"),
+    [
+        (True, True),    # device in auto-dry cycle
+        (False, False),  # not in auto-dry
+    ],
+)
+def test_auto_dry_is_on(is_auto_dry: bool, expected_is_on: bool) -> None:
+    """is_on mirrors wrapper.is_auto_dry."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.is_auto_dry = is_auto_dry
+
+    sensor = WinixBinarySensor(wrapper, Mock(), AUTO_DRY_DESC)
+
+    assert sensor.is_on == expected_is_on

--- a/tests/test_humidifier.py
+++ b/tests/test_humidifier.py
@@ -1,0 +1,383 @@
+"""Tests for Winix Dehumidifier entity."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.winix.const import (
+    ATTR_CURRENT_HUMIDITY,
+    ATTR_MODE,
+    ATTR_POWER,
+    ATTR_TARGET_HUMIDITY,
+    DEHUMIDIFIER_HUMIDITY_STEP,
+    DEHUMIDIFIER_MAX_HUMIDITY,
+    DEHUMIDIFIER_MIN_HUMIDITY,
+    DEHUMIDIFIER_MODES,
+    MODE_AUTO,
+    MODE_CLOTHES,
+    MODE_CONTINUOUS,
+    MODE_MANUAL,
+    MODE_QUIET,
+    MODE_SHOES,
+    OFF_VALUE,
+    ON_VALUE,
+    WINIX_DOMAIN,
+)
+from custom_components.winix.humidifier import WinixDehumidifier, async_setup_entry
+from homeassistant.components.humidifier import (
+    HumidifierAction,
+    HumidifierEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+
+from .common import build_fake_manager  # noqa: TID251
+
+
+def build_dehumidifier(
+    hass: HomeAssistant, device_wrapper: Mock
+) -> WinixDehumidifier:
+    """Return an initialized WinixDehumidifier instance."""
+    device = WinixDehumidifier(device_wrapper, build_fake_manager(1))
+    device.add_to_platform_start(hass, MagicMock(platform_name="test-platform"), None)
+    device.entity_id = device.unique_id
+    return device
+
+
+def _mock_dehumidifier_wrapper() -> Mock:
+    """Return a MagicMock device_wrapper configured for dehumidifier tests."""
+    wrapper = MagicMock()
+    wrapper.device_stub.mac = "aabbccddeeff"
+    wrapper.device_stub.alias = "Dehumidifier1"
+    wrapper.device_stub.model = "modelX"
+    wrapper.device_stub.sw_version = "1.0"
+    wrapper.is_dehumidifier = True
+    wrapper.is_on = False
+    wrapper.async_turn_on = AsyncMock()
+    wrapper.async_turn_off = AsyncMock()
+    wrapper.async_set_humidity = AsyncMock()
+    wrapper.async_set_mode = AsyncMock()
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_platform_adds_only_dehumidifiers(hass: HomeAssistant) -> None:
+    """Only wrappers where is_dehumidifier=True should be added."""
+    dehumidifier_wrapper = MagicMock()
+    dehumidifier_wrapper.device_stub.mac = "aabbccddeeff"
+    dehumidifier_wrapper.device_stub.alias = "Dehumidifier"
+    dehumidifier_wrapper.device_stub.model = "X"
+    dehumidifier_wrapper.device_stub.sw_version = "1"
+    dehumidifier_wrapper.is_dehumidifier = True
+
+    purifier_wrapper = MagicMock()
+    purifier_wrapper.is_dehumidifier = False
+
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[dehumidifier_wrapper, purifier_wrapper]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id1")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    assert async_add_entities.called
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], WinixDehumidifier)
+
+
+# ---------------------------------------------------------------------------
+# Construction & static attributes
+# ---------------------------------------------------------------------------
+
+
+def test_construction(hass: HomeAssistant) -> None:
+    """Test entity construction and static attributes."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={})
+
+    device = WinixDehumidifier(wrapper, Mock())
+
+    assert device.unique_id is not None
+    assert device.name is None  # primary entity
+    assert device.supported_features == HumidifierEntityFeature.MODES
+    assert device.min_humidity == DEHUMIDIFIER_MIN_HUMIDITY
+    assert device.max_humidity == DEHUMIDIFIER_MAX_HUMIDITY
+    assert device.target_humidity_step == DEHUMIDIFIER_HUMIDITY_STEP
+    assert device.available_modes == DEHUMIDIFIER_MODES
+    assert device.device_info is not None
+
+
+def test_available_modes_contains_all_modes() -> None:
+    """Ensure all expected modes are listed."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={})
+
+    device = WinixDehumidifier(wrapper, Mock())
+
+    assert set(device.available_modes) == {
+        MODE_AUTO,
+        MODE_MANUAL,
+        MODE_CLOTHES,
+        MODE_SHOES,
+        MODE_QUIET,
+        MODE_CONTINUOUS,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+def test_available_when_state_is_not_none() -> None:
+    """Entity is available when get_state returns a dict."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={})
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert device.available
+
+
+def test_unavailable_when_state_is_none() -> None:
+    """Entity is unavailable when get_state returns None."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value=None)
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert not device.available
+
+
+# ---------------------------------------------------------------------------
+# is_on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("is_on_flag", "expected"),
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_is_on(is_on_flag, expected) -> None:
+    """is_on delegates to wrapper.is_on."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.is_on = is_on_flag
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert device.is_on == expected
+
+
+# ---------------------------------------------------------------------------
+# action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("is_on_flag", "expected_action"),
+    [
+        (True, HumidifierAction.DRYING),
+        (False, HumidifierAction.OFF),
+    ],
+)
+def test_action(is_on_flag, expected_action) -> None:
+    """Action is DRYING when on, OFF otherwise."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.is_on = is_on_flag
+    wrapper.get_state = Mock(return_value={})
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert device.action == expected_action
+
+
+def test_action_returns_none_when_state_is_none() -> None:
+    """Action is None when state is None."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value=None)
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert device.action is None
+
+
+# ---------------------------------------------------------------------------
+# mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (None, None),
+        ({}, None),
+        ({ATTR_MODE: MODE_AUTO}, MODE_AUTO),
+        ({ATTR_MODE: MODE_CLOTHES}, MODE_CLOTHES),
+    ],
+)
+def test_mode(state, expected) -> None:
+    """Mode returns the current mode from state."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value=state)
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert device.mode == expected
+
+
+# ---------------------------------------------------------------------------
+# current_humidity / target_humidity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (None, None),
+        ({}, None),
+        ({ATTR_CURRENT_HUMIDITY: 55}, 55),
+        ({ATTR_CURRENT_HUMIDITY: 40}, 40),
+    ],
+)
+def test_current_humidity(state, expected) -> None:
+    """current_humidity returns the int value from state."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value=state)
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert device.current_humidity == expected
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (None, None),
+        ({}, None),
+        ({ATTR_TARGET_HUMIDITY: 50}, 50),
+        ({ATTR_TARGET_HUMIDITY: 70}, 70),
+    ],
+)
+def test_target_humidity(state, expected) -> None:
+    """target_humidity returns the int value from state."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value=state)
+
+    device = WinixDehumidifier(wrapper, Mock())
+    assert device.target_humidity == expected
+
+
+# ---------------------------------------------------------------------------
+# async_turn_on / async_turn_off
+# ---------------------------------------------------------------------------
+
+
+async def test_async_turn_on(hass: HomeAssistant) -> None:
+    """Turn on delegates to device_wrapper and requests refresh."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={ATTR_POWER: OFF_VALUE})
+
+    device = build_dehumidifier(hass, wrapper)
+
+    await device.async_turn_on()
+
+    wrapper.async_turn_on.assert_called_once()
+    device.coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_async_turn_off(hass: HomeAssistant) -> None:
+    """Turn off delegates to device_wrapper and requests refresh."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={ATTR_POWER: ON_VALUE})
+
+    device = build_dehumidifier(hass, wrapper)
+
+    await device.async_turn_off()
+
+    wrapper.async_turn_off.assert_called_once()
+    device.coordinator.async_request_refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# async_set_humidity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("humidity", [35, 40, 45, 50, 55, 60, 65, 70])
+async def test_async_set_humidity_exact_steps(hass: HomeAssistant, humidity: int) -> None:
+    """Exact 5-step values are passed through unchanged."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={})
+
+    device = build_dehumidifier(hass, wrapper)
+
+    await device.async_set_humidity(humidity)
+
+    wrapper.async_set_humidity.assert_called_once_with(humidity)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (34, 35),   # rounds up to min
+        (37, 35),   # rounds down (7.4 -> 7 -> 35)
+        (38, 40),   # rounds up (7.6 -> 8 -> 40)
+        (57, 55),   # rounds down (11.4 -> 11 -> 55)
+        (58, 60),   # rounds up (11.6 -> 12 -> 60)
+        (71, 70),   # rounds down, then clamped to max
+        (0, 35),    # rounds to 0, clamped to min
+        (100, 70),  # rounds to 100, clamped to max
+    ],
+)
+async def test_async_set_humidity_rounds_and_clamps(
+    hass: HomeAssistant, raw: int, expected: int
+) -> None:
+    """Non-step or out-of-range values are rounded to nearest step then clamped."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={})
+
+    device = build_dehumidifier(hass, wrapper)
+
+    await device.async_set_humidity(raw)
+
+    wrapper.async_set_humidity.assert_called_once_with(expected)
+
+
+# ---------------------------------------------------------------------------
+# async_set_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [MODE_AUTO, MODE_MANUAL, MODE_CLOTHES, MODE_SHOES, MODE_QUIET, MODE_CONTINUOUS],
+)
+async def test_async_set_mode_valid(hass: HomeAssistant, mode: str) -> None:
+    """Valid modes delegate to wrapper.async_set_mode without coordinator refresh."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={})
+
+    device = build_dehumidifier(hass, wrapper)
+
+    await device.async_set_mode(mode)
+
+    wrapper.async_set_mode.assert_called_once_with(mode)
+    device.coordinator.async_request_refresh.assert_not_called()
+
+
+async def test_async_set_mode_passes_through(hass: HomeAssistant) -> None:
+    """Entity passes mode through; wrapper is responsible for validation."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={})
+
+    device = build_dehumidifier(hass, wrapper)
+
+    await device.async_set_mode("turbo_dry")
+
+    wrapper.async_set_mode.assert_called_once_with("turbo_dry")

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,164 @@
+"""Tests for Winix Number entity (dehumidifier timer)."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.winix.const import ATTR_TIMER, WINIX_DOMAIN
+from custom_components.winix.number import (
+    NUMBER_DESCRIPTIONS,
+    WinixNumberEntity,
+    async_setup_entry,
+)
+from homeassistant.core import HomeAssistant
+
+from .common import build_fake_manager  # noqa: TID251
+
+
+def _mock_dehumidifier_wrapper(index: int = 0) -> MagicMock:
+    """Return a MagicMock device_wrapper configured as a dehumidifier."""
+    wrapper = MagicMock()
+    wrapper.device_stub.mac = f"aabbccddee{index:02x}"
+    wrapper.device_stub.alias = f"Dehumidifier{index}"
+    wrapper.device_stub.model = "modelX"
+    wrapper.device_stub.sw_version = "1.0"
+    wrapper.is_dehumidifier = True
+    wrapper.async_set_timer = AsyncMock()
+    return wrapper
+
+
+def _mock_purifier_wrapper() -> MagicMock:
+    """Return a MagicMock device_wrapper configured as an air purifier."""
+    wrapper = MagicMock()
+    wrapper.is_dehumidifier = False
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_platform_adds_timer_for_dehumidifiers(
+    hass: HomeAssistant,
+) -> None:
+    """Timer entity is created only for dehumidifier wrappers."""
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[_mock_dehumidifier_wrapper(0), _mock_purifier_wrapper()]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id1")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    assert async_add_entities.called
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], WinixNumberEntity)
+
+
+async def test_setup_platform_multiple_dehumidifiers(hass: HomeAssistant) -> None:
+    """One timer entity is created per dehumidifier."""
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[_mock_dehumidifier_wrapper(0), _mock_dehumidifier_wrapper(1)]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id2")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 2
+
+
+async def test_setup_platform_no_dehumidifiers(hass: HomeAssistant) -> None:
+    """No number entities are added when there are no dehumidifiers."""
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[_mock_purifier_wrapper(), _mock_purifier_wrapper()]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id3")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 0
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_construction() -> None:
+    """unique_id and entity_description are properly set; ranges match spec."""
+    wrapper = _mock_dehumidifier_wrapper()
+    description = NUMBER_DESCRIPTIONS[0]  # timer
+
+    entity = WinixNumberEntity(wrapper, Mock(), description)
+
+    assert entity.unique_id is not None
+    assert "timer" in entity.unique_id
+    assert entity.entity_description is description
+    assert entity.native_min_value == 0
+    assert entity.native_max_value == 24
+    assert entity.native_step == 1
+
+
+# ---------------------------------------------------------------------------
+# native_value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ({ATTR_TIMER: 0}, 0),
+        ({ATTR_TIMER: 8}, 8),
+        ({ATTR_TIMER: 24}, 24),
+        ({}, None),
+    ],
+)
+def test_native_value(state, expected) -> None:
+    """native_value returns the timer value from device state."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value=state)
+
+    description = NUMBER_DESCRIPTIONS[0]  # timer
+    entity = WinixNumberEntity(wrapper, Mock(), description)
+
+    assert entity.native_value == expected
+
+
+# ---------------------------------------------------------------------------
+# async_set_native_value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hours", [0, 1, 8, 24])
+async def test_async_set_native_value(hass: HomeAssistant, hours: int) -> None:
+    """Setting a value delegates to async_set_timer with an integer argument."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={ATTR_TIMER: 0})
+
+    description = NUMBER_DESCRIPTIONS[0]  # timer
+    entity = WinixNumberEntity(wrapper, build_fake_manager(1), description)
+    entity.add_to_platform_start(hass, MagicMock(platform_name="test-platform"), None)
+    entity.entity_id = entity.unique_id
+
+    await entity.async_set_native_value(float(hours))
+
+    wrapper.async_set_timer.assert_called_once_with(hours)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,137 @@
+"""Tests for Winix Select entities."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.winix.const import WINIX_DOMAIN
+from custom_components.winix.select import (
+    SELECT_DESCRIPTIONS,
+    WinixSelectEntity,
+    async_setup_entry,
+)
+from homeassistant.core import HomeAssistant
+
+from .common import build_fake_manager  # noqa: TID251
+
+# Descriptions by key for convenient lookup
+_DESC_BY_KEY = {d.key: d for d in SELECT_DESCRIPTIONS}
+BRIGHTNESS_DESC = _DESC_BY_KEY["brightness_level"]
+FAN_SPEED_DESC = _DESC_BY_KEY["fan_speed"]
+
+
+def _mock_dehumidifier_wrapper() -> MagicMock:
+    wrapper = MagicMock()
+    wrapper.device_stub.mac = "aabbccddeeff"
+    wrapper.device_stub.alias = "Dehumidifier1"
+    wrapper.device_stub.model = "modelX"
+    wrapper.device_stub.sw_version = "1.0"
+    wrapper.is_dehumidifier = True
+    wrapper.features.supports_brightness_level = False
+    wrapper.async_set_speed = AsyncMock(return_value=True)
+    return wrapper
+
+
+def _mock_purifier_wrapper() -> MagicMock:
+    wrapper = MagicMock()
+    wrapper.device_stub.mac = "aabbccddeeff"
+    wrapper.device_stub.alias = "Purifier1"
+    wrapper.device_stub.model = "modelY"
+    wrapper.device_stub.sw_version = "1.0"
+    wrapper.is_dehumidifier = False
+    wrapper.features.supports_brightness_level = True
+    wrapper.async_set_brightness_level = AsyncMock(return_value=True)
+    wrapper.is_on = True
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_creates_fan_speed_for_dehumidifier(hass: HomeAssistant) -> None:
+    """fan_speed select is created for dehumidifier wrappers; brightness for AP."""
+    manager = MagicMock()
+    manager.get_device_wrappers = Mock(
+        return_value=[_mock_dehumidifier_wrapper(), _mock_purifier_wrapper()]
+    )
+    manager.async_request_refresh = AsyncMock()
+
+    config = MockConfigEntry(domain=WINIX_DOMAIN, data={}, entry_id="id1")
+    config.runtime_data = manager
+    async_add_entities = Mock()
+
+    await async_setup_entry(hass, config, async_add_entities)
+
+    entities = async_add_entities.call_args[0][0]
+    keys = [e.entity_description.key for e in entities]
+    assert "fan_speed" in keys
+    assert "brightness_level" in keys
+
+
+# ---------------------------------------------------------------------------
+# available -- brightness_level uses available_fn (is_on)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("is_on", "expected_available"),
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_brightness_available_follows_is_on(is_on, expected_available) -> None:
+    """brightness_level entity is available only when device is on."""
+    wrapper = _mock_purifier_wrapper()
+    wrapper.is_on = is_on
+    wrapper.get_state = Mock(return_value={})
+
+    entity = WinixSelectEntity(wrapper, Mock(), BRIGHTNESS_DESC)
+
+    assert entity.available == expected_available
+
+
+# ---------------------------------------------------------------------------
+# available -- fan_speed falls back to base WinixEntity.available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_available"),
+    [
+        ({}, True),   # state present -> available regardless of power
+        (None, False),  # state None -> unavailable
+    ],
+)
+def test_fan_speed_available_follows_state(state, expected_available) -> None:
+    """fan_speed entity is available whenever state is not None (power-agnostic)."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value=state)
+
+    entity = WinixSelectEntity(wrapper, Mock(), FAN_SPEED_DESC)
+
+    assert entity.available == expected_available
+
+
+# ---------------------------------------------------------------------------
+# async_select_option -- no coordinator refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_async_select_option_no_coordinator_refresh(hass: HomeAssistant) -> None:
+    """Selecting an option must NOT trigger coordinator.async_request_refresh."""
+    wrapper = _mock_dehumidifier_wrapper()
+    wrapper.get_state = Mock(return_value={"airflow": "high"})
+
+    coordinator = build_fake_manager(1)
+    entity = WinixSelectEntity(wrapper, coordinator, FAN_SPEED_DESC)
+    entity.add_to_platform_start(hass, MagicMock(platform_name="test-platform"), None)
+    entity.entity_id = entity.unique_id
+
+    await entity.async_select_option("low")
+
+    coordinator.async_request_refresh.assert_not_called()
+    wrapper.async_set_speed.assert_called_once_with("low")


### PR DESCRIPTION
Closes #151

Hi, I've finally completed the work.

The first three commits are simple refactoring and fix. The fourth commit modifies the codebase to support multiple device types, and the fifth commit is a straightforward docstring update.

The sixth commit adds the dehumidifier device type. At this stage, the dehumidifier device type is added but not yet activated, so there should be no interference with the existing air purifier functionality.

The seventh commit adds device group recognition to distinguish between device types. The eighth and nineth commits add Home Assistant entities for the dehumidifier, where entities are created based on their respective device types.

At this stage, air purifiers and dehumidifiers are actually distinguished and recognized separately, so if there are any bugs, they could potentially affect air purifier functionality. If reviewing the entire PR feels like too much at once, feel free to merge commits 1–6 first, and then merge commits 7–9 afterward in a separate phase.

Each commit contains a detailed message describing the changes.

To be completely transparent, I authored nearly all of the driver and device_wrapper code and about half of the HA entities myself. I then utilized AI tools to complete the remaining tasks. While I have a 100% understanding of the driver and device_wrapper logic through my own writing and review, I am less familiar with the HA entity framework, so my understanding there is roughly 80%, and about 50% for the unit tests. Crucially, however, live testing confirmed that only the relevant dehumidifier entities are being recognized and that all core functions are operating as expected.

Once this PR is merged, documentation updates (e.g., README.md) will be needed. Beyond that, I plan to contribute further with internationalization support (making better use of `en.json`), additional refactoring, and bug fixes.