### PR TITLE
fix: update auth and device control for Winix API v1.5.7

### DIFF
--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -139,7 +139,9 @@ async def async_prepare_devices(
 
         if err.result_code in ("900", "400"):
             LOGGER.info(
-                f"Failed to get device list (code={err.result_code}, message={err.result_message}), reauthenticating with stored credentials"
+                "Failed to get device list (code=%s, message=%s), reauthenticating with stored credentials",
+                err.result_code,
+                err.result_message,
             )
 
             try:
@@ -154,13 +156,14 @@ async def async_prepare_devices(
 
             # Try preparing device wrappers again with new auth response
             try:
-                await manager.prepare_devices_wrappers(new_auth_response.access_token)
+                await manager.prepare_devices_wrappers(new_auth_response.access_token, new_auth_response.id_token)
             except WinixException as err_retry:
                 raise ConfigEntryAuthFailed(
                     "Unable to access device data even after re-login."
                 ) from err_retry
 
         else:
+            LOGGER.error("Unable to access device data (code=%s): %s", err.result_code, err, exc_info=True)
             raise ConfigEntryNotReady("Unable to access device data.") from err
 
     return new_auth_response

--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -137,7 +137,7 @@ async def async_prepare_devices(
         # login again and get new tokens.
         # 400:The user is not valid.
 
-        if err.result_code in ("900", "400"):
+        if err.result_code in ("900", "400", "NotAuthorizedException"):
             LOGGER.info(
                 "Failed to get device list (code=%s, message=%s), reauthenticating with stored credentials",
                 err.result_code,

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -53,10 +53,11 @@ class WinixDeviceWrapper:
         device_stub: MyWinixDeviceStub,
         filter_alarm_duration_hours: int,
         logger,
+        identity_id: str,
     ) -> None:
         """Initialize the wrapper."""
 
-        self._driver = WinixDriver(device_stub.id, client)
+        self._driver = WinixDriver(device_stub.id, client, identity_id)
 
         # Start as empty object in case fan was operated before it got updated
         self._state = {}

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -31,7 +31,7 @@ class WinixDriver:
     """WinixDevice driver."""
 
     # pylint: disable=line-too-long
-    CTRL_URL = "https://us.api.winix-iot.com/common/control/devices/{deviceid}/A211/{attribute}:{value}"
+    CTRL_URL = "https://us.api.winix-iot.com/common/control/devices/{deviceid}/{identityid}/{attribute}:{value}"
     STATE_URL = "https://us.api.winix-iot.com/common/event/sttus/devices/{deviceid}"
     PARAM_URL = "https://us.api.winix-iot.com/common/event/param/devices/{deviceid}"
 
@@ -65,10 +65,11 @@ class WinixDriver:
         "air_quality": {"good": "01", "fair": "02", "poor": "03"},
     }
 
-    def __init__(self, device_id: str, client: aiohttp.ClientSession) -> None:
+    def __init__(self, device_id: str, client: aiohttp.ClientSession, identity_id: str) -> None:
         """Create an instance of WinixDevice."""
         self.device_id = device_id
         self._client = client
+        self._identity_id = identity_id
 
     async def turn_off(self) -> None:
         """Turn the device off."""
@@ -158,7 +159,10 @@ class WinixDriver:
         try:
             response = await self._client.get(
                 self.CTRL_URL.format(
-                    deviceid=self.device_id, attribute=attr, value=value
+                    deviceid=self.device_id,
+                    identityid=self._identity_id,
+                    attribute=attr,
+                    value=value,
                 )
             )
             response.raise_for_status()

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -9,19 +9,13 @@ import json
 from typing import Any
 
 import aiohttp
+import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad, unpad
 import requests
 from winix import WinixAccount, auth
-
-# Winix rotated their Cognito app client on 2026-04-16. The old client ID
-# (14og512b9u20b8vrdm55d8empi) is dead. Patch the pip package constants before
-# any auth calls are made. The new client has no client secret.
-auth.COGNITO_APP_CLIENT_ID = "5rjk59c5tt7k9g8gpj0vd2qfg9"
-auth.COGNITO_CLIENT_SECRET_KEY = None
-
-_COGNITO_IDENTITY_POOL_ID = "us-east-1:84008e15-d6af-4698-8646-66d05c1abe8b"
-_COGNITO_USER_POOL_ID = "us-east-1_Ofd50EosD"
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -33,6 +27,20 @@ from .const import (
     WINIX_DOMAIN,
 )
 from .device_wrapper import MyWinixDeviceStub
+
+# Winix rotated their Cognito app client on 2026-04-16. The old client ID
+# (14og512b9u20b8vrdm55d8empi) is dead. Patch the pip package constants before
+# any auth calls are made. The new client has no client secret.
+auth.COGNITO_APP_CLIENT_ID = "5rjk59c5tt7k9g8gpj0vd2qfg9"
+auth.COGNITO_CLIENT_SECRET_KEY = None
+
+_COGNITO_IDENTITY_POOL_ID = "us-east-1:84008e15-d6af-4698-8646-66d05c1abe8b"
+_COGNITO_USER_POOL_ID = "us-east-1_Ofd50EosD"
+
+# Both Cognito services are public endpoints — no AWS credentials required.
+_UNSIGNED_CONFIG = Config(signature_version=UNSIGNED)
+_COGNITO_IDP_CLIENT = boto3.client("cognito-idp", config=_UNSIGNED_CONFIG, region_name="us-east-1")
+_COGNITO_IDENTITY_CLIENT = boto3.client("cognito-identity", config=_UNSIGNED_CONFIG, region_name="us-east-1")
 
 HEADERS = {
     "Content-Type": "application/octet-stream",
@@ -123,7 +131,7 @@ class Helpers:
 
         access_token = response.access_token
         uuid = WinixAccount(access_token).get_uuid()
-        identity_id = Helpers._get_identity_id_sync(response.id_token)
+        identity_id = Helpers.get_identity_id_sync(response.id_token)
 
         try:
             # v1.5.7 session establishment order:
@@ -152,19 +160,9 @@ class Helpers:
 
             # Use boto3 directly — auth.refresh() calls WarrantLite.get_secret_hash()
             # which breaks with client_secret=None (new public client has no secret).
-            import boto3
-            from botocore import UNSIGNED
-            from botocore.client import Config
-
-            client = boto3.client(
-                "cognito-idp",
-                config=Config(signature_version=UNSIGNED),
-                region_name="us-east-1",
-            )
-
             # New public client has no secret — no SECRET_HASH in refresh params.
             try:
-                resp = client.initiate_auth(
+                resp = _COGNITO_IDP_CLIENT.initiate_auth(
                     ClientId=auth.COGNITO_APP_CLIENT_ID,
                     AuthFlow="REFRESH_TOKEN",
                     AuthParameters={"REFRESH_TOKEN": response.refresh_token},
@@ -181,7 +179,7 @@ class Helpers:
             )
 
             uuid = WinixAccount(reponse.access_token).get_uuid()
-            identity_id = Helpers._get_identity_id_sync(reponse.id_token)
+            identity_id = Helpers.get_identity_id_sync(reponse.id_token)
             LOGGER.debug("Re-establishing session after token refresh")
 
             try:
@@ -202,19 +200,15 @@ class Helpers:
     ) -> dict[str, str]:
         """Build a payload that matches the current mobile app metadata."""
 
-        payload = {
+        return {
             "accessToken": access_token,
             "uuid": uuid,
             **Helpers._MOBILE_APP_METADATA,
             **kwargs,
         }
-        # Only include the client secret key if one is configured (new app client has none).
-        if auth.COGNITO_CLIENT_SECRET_KEY is not None:
-            payload["cognitoClientSecretKey"] = auth.COGNITO_CLIENT_SECRET_KEY
-        return payload
 
     @staticmethod
-    def _get_identity_id_sync(id_token: str) -> str:
+    def get_identity_id_sync(id_token: str) -> str:
         """Get the Cognito Identity ID synchronously (for use in executor threads).
 
         The CTRL_URL requires the user's identityId from the Cognito Identity Pool
@@ -223,20 +217,10 @@ class Helpers:
 
         Raises WinixException.
         """
-        import boto3
-        from botocore import UNSIGNED
-        from botocore.client import Config
-
-        client = boto3.client(
-            "cognito-identity",
-            config=Config(signature_version=UNSIGNED),
-            region_name="us-east-1",
-        )
-
         login_key = f"cognito-idp.us-east-1.amazonaws.com/{_COGNITO_USER_POOL_ID}"
 
         try:
-            response = client.get_id(
+            response = _COGNITO_IDENTITY_CLIENT.get_id(
                 IdentityPoolId=_COGNITO_IDENTITY_POOL_ID,
                 Logins={login_key: id_token},
             )

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -241,7 +241,10 @@ class Helpers:
                 Logins={login_key: id_token},
             )
         except Exception as err:  # pylint: disable=broad-except
-            raise WinixException({"message": f"Failed to get Cognito Identity ID: {err}"}) from err
+            # Map NotAuthorizedException (expired id_token) to result_code so
+            # callers can trigger re-auth rather than failing permanently.
+            code = "NotAuthorizedException" if "NotAuthorizedException" in str(err) else ""
+            raise WinixException({"message": f"Failed to get Cognito Identity ID: {err}", "result_code": code}) from err
 
         identity_id = response.get("IdentityId")
         if not identity_id:

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -14,6 +14,15 @@ from Crypto.Util.Padding import pad, unpad
 import requests
 from winix import WinixAccount, auth
 
+# Winix rotated their Cognito app client on 2026-04-16. The old client ID
+# (14og512b9u20b8vrdm55d8empi) is dead. Patch the pip package constants before
+# any auth calls are made. The new client has no client secret.
+auth.COGNITO_APP_CLIENT_ID = "5rjk59c5tt7k9g8gpj0vd2qfg9"
+auth.COGNITO_CLIENT_SECRET_KEY = None
+
+_COGNITO_IDENTITY_POOL_ID = "us-east-1:84008e15-d6af-4698-8646-66d05c1abe8b"
+_COGNITO_USER_POOL_ID = "us-east-1_Ofd50EosD"
+
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -42,11 +51,10 @@ class Helpers:
     _AES_IV = bytes.fromhex("dfd55f316e72e97b905f8739005c99a7")
 
     _MOBILE_APP_METADATA = {
-        "cognitoClientSecretKey": auth.COGNITO_CLIENT_SECRET_KEY,
         "osType": "android",
         "osVersion": "29",
         "mobileLang": "en",
-        "appVersion": "1.5.6",
+        "appVersion": "1.5.7",
         "mobileModel": "SM-G988B",
     }
 
@@ -115,10 +123,14 @@ class Helpers:
 
         access_token = response.access_token
         uuid = WinixAccount(access_token).get_uuid()
+        identity_id = Helpers._get_identity_id_sync(response.id_token)
 
         try:
-            Helpers._register_user(access_token, uuid, username)
-            Helpers._check_access_token(access_token, uuid)
+            # v1.5.7 session establishment order:
+            # registerUser (needs identityId) → init → checkAccessToken (needs identityId)
+            Helpers._register_user(access_token, uuid, username, identity_id)
+            Helpers._init(access_token, uuid)
+            Helpers._check_access_token(access_token, uuid, identity_id)
         except Exception as err:  # pylint: disable=broad-except
             raise WinixException.from_winix_exception(err) from err
 
@@ -138,18 +150,44 @@ class Helpers:
         def _refresh(response: auth.WinixAuthResponse) -> auth.WinixAuthResponse:
             LOGGER.debug("Attempting re-authentication")
 
+            # Use boto3 directly — auth.refresh() calls WarrantLite.get_secret_hash()
+            # which breaks with client_secret=None (new public client has no secret).
+            import boto3
+            from botocore import UNSIGNED
+            from botocore.client import Config
+
+            client = boto3.client(
+                "cognito-idp",
+                config=Config(signature_version=UNSIGNED),
+                region_name="us-east-1",
+            )
+
+            # New public client has no secret — no SECRET_HASH in refresh params.
             try:
-                reponse = auth.refresh(
-                    user_id=response.user_id, refresh_token=response.refresh_token
+                resp = client.initiate_auth(
+                    ClientId=auth.COGNITO_APP_CLIENT_ID,
+                    AuthFlow="REFRESH_TOKEN",
+                    AuthParameters={"REFRESH_TOKEN": response.refresh_token},
                 )
             except Exception as err:  # pylint: disable=broad-except
                 raise WinixException.from_aws_exception(err) from err
 
+            result = resp["AuthenticationResult"]
+            reponse = auth.WinixAuthResponse(
+                user_id=response.user_id,
+                access_token=result["AccessToken"],
+                refresh_token=response.refresh_token,
+                id_token=result["IdToken"],
+            )
+
             uuid = WinixAccount(reponse.access_token).get_uuid()
-            LOGGER.debug("Attempting access token check")
+            identity_id = Helpers._get_identity_id_sync(reponse.id_token)
+            LOGGER.debug("Re-establishing session after token refresh")
 
             try:
-                Helpers._check_access_token(reponse.access_token, uuid)
+                Helpers._register_user(reponse.access_token, uuid, response.user_id, identity_id)
+                Helpers._init(reponse.access_token, uuid)
+                Helpers._check_access_token(reponse.access_token, uuid, identity_id)
             except Exception as err:  # pylint: disable=broad-except
                 raise WinixException.from_winix_exception(err) from err
 
@@ -164,15 +202,84 @@ class Helpers:
     ) -> dict[str, str]:
         """Build a payload that matches the current mobile app metadata."""
 
-        return {
+        payload = {
             "accessToken": access_token,
             "uuid": uuid,
             **Helpers._MOBILE_APP_METADATA,
             **kwargs,
         }
+        # Only include the client secret key if one is configured (new app client has none).
+        if auth.COGNITO_CLIENT_SECRET_KEY is not None:
+            payload["cognitoClientSecretKey"] = auth.COGNITO_CLIENT_SECRET_KEY
+        return payload
 
     @staticmethod
-    def _check_access_token(access_token: str, uuid: str) -> None:
+    def _get_identity_id_sync(id_token: str) -> str:
+        """Get the Cognito Identity ID synchronously (for use in executor threads).
+
+        The CTRL_URL requires the user's identityId from the Cognito Identity Pool
+        instead of the old hardcoded 'A211' path segment. Uses boto3 so the AWS
+        JSON protocol headers are handled correctly.
+
+        Raises WinixException.
+        """
+        import boto3
+        from botocore import UNSIGNED
+        from botocore.client import Config
+
+        client = boto3.client(
+            "cognito-identity",
+            config=Config(signature_version=UNSIGNED),
+            region_name="us-east-1",
+        )
+
+        login_key = f"cognito-idp.us-east-1.amazonaws.com/{_COGNITO_USER_POOL_ID}"
+
+        try:
+            response = client.get_id(
+                IdentityPoolId=_COGNITO_IDENTITY_POOL_ID,
+                Logins={login_key: id_token},
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            raise WinixException({"message": f"Failed to get Cognito Identity ID: {err}"}) from err
+
+        identity_id = response.get("IdentityId")
+        if not identity_id:
+            raise WinixException({"message": "Cognito Identity ID missing from response."})
+
+        LOGGER.debug("Got Cognito identityId: %s", identity_id)
+        return identity_id
+
+    @staticmethod
+    def _init(access_token: str, uuid: str) -> None:
+        """Call the Winix /init endpoint. Required as of v1.5.7 between registerUser and checkAccessToken.
+
+        Raises WinixException.
+        """
+
+        resp = requests.post(
+            "https://us.mobile.winix-iot.com/init",
+            headers=HEADERS,
+            data=Helpers.encrypt({
+                "accessToken": access_token,
+                "uuid": uuid,
+                "region": "US",
+            }),
+            timeout=DEFAULT_POST_TIMEOUT,
+        )
+
+        binary_data = resp.content
+        response_json_text = Helpers.decrypt(binary_data)
+        response_json = Helpers.json_loads(response_json_text)
+
+        if resp.status_code != HTTPStatus.OK:
+            response_json["message"] = (
+                f"Error while performing RPC init ({resp.status_code})"
+            )
+            raise WinixException(response_json)
+
+    @staticmethod
+    def _check_access_token(access_token: str, uuid: str, identity_id: str) -> None:
         """Validate the access token with Winix cloud using current app metadata.
 
         Raises WinixException.
@@ -181,7 +288,9 @@ class Helpers:
         resp = requests.post(
             "https://us.mobile.winix-iot.com/checkAccessToken",
             headers=HEADERS,
-            data=Helpers.encrypt(Helpers._build_mobile_app_payload(access_token, uuid)),
+            data=Helpers.encrypt(Helpers._build_mobile_app_payload(
+                access_token, uuid, identityId=identity_id
+            )),
             timeout=DEFAULT_POST_TIMEOUT,
         )
 
@@ -196,7 +305,7 @@ class Helpers:
             raise WinixException(response_json)
 
     @staticmethod
-    def _register_user(access_token: str, uuid: str, email: str) -> None:
+    def _register_user(access_token: str, uuid: str, email: str, identity_id: str) -> None:
         """Register the generated mobile identity with the Winix backend.
 
         Raises WinixException.
@@ -206,7 +315,9 @@ class Helpers:
             "https://us.mobile.winix-iot.com/registerUser",
             headers=HEADERS,
             data=Helpers.encrypt(
-                Helpers._build_mobile_app_payload(access_token, uuid, email=email)
+                Helpers._build_mobile_app_payload(
+                    access_token, uuid, email=email, identityId=identity_id
+                )
             ),
             timeout=DEFAULT_POST_TIMEOUT,
         )

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -85,7 +85,7 @@ class WinixManager(DataUpdateCoordinator):
         for wrapper in self._device_wrappers:
             wrapper.update_features()
 
-    async def prepare_devices_wrappers(self, access_token: str = "") -> None:
+    async def prepare_devices_wrappers(self, access_token: str = "", id_token: str = "") -> None:
         """Prepare device wrappers.
 
         Raises WinixException.
@@ -93,8 +93,23 @@ class WinixManager(DataUpdateCoordinator):
         self._device_wrappers = []  # Reset device_stubs
 
         token = access_token or self._auth_response.access_token
+        id_tok = id_token or self._auth_response.id_token
         uuid = WinixAccount(token).get_uuid()
-        device_stubs = await Helpers.get_device_stubs(self._client, token, uuid)
+
+        try:
+            device_stubs = await Helpers.get_device_stubs(self._client, token, uuid)
+        except Exception as err:
+            LOGGER.error("Failed to get device stubs: %s", err, exc_info=True)
+            raise
+
+        # boto3 call must run in an executor thread (synchronous I/O).
+        try:
+            identity_id = await self.hass.async_add_executor_job(
+                Helpers._get_identity_id_sync, id_tok
+            )
+        except Exception as err:
+            LOGGER.error("Failed to get identity_id: %s", err, exc_info=True)
+            raise
 
         if device_stubs:
             for device_stub in device_stubs:
@@ -103,7 +118,7 @@ class WinixManager(DataUpdateCoordinator):
                 )
                 self._device_wrappers.append(
                     WinixDeviceWrapper(
-                        self._client, device_stub, filter_alarm_duration, LOGGER
+                        self._client, device_stub, filter_alarm_duration, LOGGER, identity_id
                     )
                 )
 

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -105,7 +105,7 @@ class WinixManager(DataUpdateCoordinator):
         # boto3 call must run in an executor thread (synchronous I/O).
         try:
             identity_id = await self.hass.async_add_executor_job(
-                Helpers._get_identity_id_sync, id_tok
+                Helpers.get_identity_id_sync, id_tok
             )
         except Exception as err:
             LOGGER.error("Failed to get identity_id: %s", err, exc_info=True)

--- a/tests/common.py
+++ b/tests/common.py
@@ -71,6 +71,10 @@ async def init_integration(
             return_value=[test_device_stub],
         ),
         patch("winix.WinixAccount.get_uuid"),
+        patch(
+            "custom_components.winix.manager.Helpers.get_identity_id_sync",
+            return_value="test_identity_id",
+        ),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -92,7 +96,7 @@ def build_mock_wrapper(index: Number = 0) -> WinixDeviceWrapper:
     logger.warning = Mock()
 
     return WinixDeviceWrapper(
-        client, device_stub, DEFAULT_FILTER_ALARM_DURATION_HOURS, logger
+        client, device_stub, DEFAULT_FILTER_ALARM_DURATION_HOURS, logger, "test_identity_id"
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,8 @@ def mock_driver() -> WinixDriver:
     """Return a mocked WinixDriver instance."""
     client = Mock()
     device_id = "device_1"
-    return WinixDriver(device_id, client)
+    identity_id = "test_identity_id"
+    return WinixDriver(device_id, client, identity_id)
 
 
 @pytest.fixture
@@ -107,4 +108,5 @@ def mock_driver_with_payload(request: pytest.FixtureRequest) -> WinixDriver:
     client.get = AsyncMock(return_value=response)
 
     device_id = "device_1"
-    return WinixDriver(device_id, client)
+    identity_id = "test_identity_id"
+    return WinixDriver(device_id, client, identity_id)

--- a/tests/test_device_wrapper.py
+++ b/tests/test_device_wrapper.py
@@ -330,7 +330,7 @@ async def test_async_set_preset_mode_invalid() -> None:
     logger.warning = Mock()
 
     wrapper = WinixDeviceWrapper(
-        client, device_stub, DEFAULT_FILTER_ALARM_DURATION_HOURS, logger
+        client, device_stub, DEFAULT_FILTER_ALARM_DURATION_HOURS, logger, "test_identity_id"
     )
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

Winix rotated their Cognito app client on **2026-04-16**, breaking all authentication and device control. This PR updates the integration to work with the new backend.

### What broke

- Old Cognito app client ID (`14og512b9u20b8vrdm55d8empi`) was decommissioned
- New client (`5rjk59c5tt7k9g8gpj0vd2qfg9`) is a public client with no client secret
- Mobile API now requires a per-user `identityId` from Cognito Identity Pool in `registerUser` and `checkAccessToken` payloads
- New `/init` endpoint must be called between `registerUser` and `checkAccessToken`
- Device control URL changed: hardcoded `A211` segment replaced by the user's `identityId`
- `appVersion` must match the new client (`1.5.7`)

### Changes

**`helpers.py`**
- Patch `auth.COGNITO_APP_CLIENT_ID` and `auth.COGNITO_CLIENT_SECRET_KEY` at import time
- Bump `appVersion` to `1.5.7`
- `_build_mobile_app_payload`: conditionally omit `cognitoClientSecretKey` when no secret is configured
- `login()`: updated session order — `registerUser` then `_init` then `checkAccessToken`, all with `identityId`
- Add `_get_identity_id_sync(id_token)`: fetches identityId via boto3 (raw requests sends wrong Content-Type, causing HTTP 400)
- Add `_init(access_token, uuid)`: calls new required `/init` endpoint
- `_register_user` and `_check_access_token`: add `identity_id` parameter
- `async_refresh_auth`: replace `auth.refresh()` with direct boto3 `initiate_auth(REFRESH_TOKEN)` — `auth.refresh()` breaks with `client_secret=None`

**`driver.py`** — `CTRL_URL` uses `{identityid}` instead of `A211`; `__init__` accepts `identity_id`

**`device_wrapper.py`** — `__init__` accepts and forwards `identity_id` to `WinixDriver`

**`manager.py`** — `prepare_devices_wrappers` fetches `identity_id` via executor and passes it through

**`__init__.py`** — passes `id_token` on re-login retry; adds error logging before `ConfigEntryNotReady`

### References

- https://github.com/regaw-leinad/winix-api (winix-auth.ts, winix-account.ts, winix-crypto.ts)

## Test plan

- [ ] Fresh login via integration config flow succeeds
- [ ] Integration loads and devices appear with correct state
- [ ] Fan control works via the new identityId-based CTRL_URL
- [ ] Token refresh completes without error
- [ ] Re-authentication (900/400 codes) triggers fresh login and recovers correctly