### PR TITLE
fix: handle integration unload gracefully

### DIFF
--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -224,8 +224,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(
         entry, SUPPORTED_PLATFORMS
     )
-    if unload_ok:
-        hass.data.pop(WINIX_DOMAIN)
 
     other_loaded_entries = [
         _entry


### PR DESCRIPTION
Commit https://github.com/iprak/winix/commit/c59df4d6b67ada25f7fb5d1880b263658ae1d25c simplified the manager storage, 
it is no longer saved into hass.data[WINIX_DOMAIN] but did not clean the unload part which causes an exception when disabling/unloading the integration.