### PR TITLE
fix: retry sooner on transient DNS failures during device update

### DIFF
--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -13,6 +13,11 @@ from .const import ATTR_PM25, LOGGER
 
 # Modified from https://github.com/hfern/winix to support async operations
 
+
+class WinixTransientError(HomeAssistantError):
+    """Raised for transient network errors that may resolve on retry."""
+
+
 ATTR_BRIGHTNESS_LEVEL: Final = "brightness_level"
 ATTR_CHILD_LOCK: Final = "child_lock"
 
@@ -243,13 +248,13 @@ class WinixDriver:
             response.raise_for_status()
             json = await response.json()
         except aiohttp.ClientResponseError as err:
-            raise HomeAssistantError(
+            raise WinixTransientError(
                 f"Failed to download data: HTTP {err.status}"
             ) from err
         except aiohttp.ClientError as err:
-            raise HomeAssistantError(f"Error communicating with Winix: {err}") from err
+            raise WinixTransientError(f"Error communicating with Winix: {err}") from err
         except TimeoutError as err:
-            raise HomeAssistantError("Timeout communicating with Winix") from err
+            raise WinixTransientError("Timeout communicating with Winix") from err
 
         # pylint: disable=pointless-string-statement
         """

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-import aiohttp
 from winix import WinixAccount, auth
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -19,6 +17,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import LOGGER, WINIX_DOMAIN
 from .device_wrapper import WinixDeviceWrapper
+from .driver import WinixTransientError
 from .helpers import Helpers
 
 
@@ -70,6 +69,7 @@ class WinixManager(DataUpdateCoordinator):
         self._device_wrappers: list[WinixDeviceWrapper] = []
         self._auth_response = auth_response
         self._client = client
+        self._retry_on_error = False
 
         super().__init__(
             hass,
@@ -86,10 +86,15 @@ class WinixManager(DataUpdateCoordinator):
         try:
             for device_wrapper in self._device_wrappers:
                 await device_wrapper.update()
-        except HomeAssistantError as err:
-            if isinstance(err.__cause__, aiohttp.ClientConnectorDNSError):
+            self._retry_on_error = False
+        except WinixTransientError as err:
+            if not self._retry_on_error:
+                self._retry_on_error = True
+                LOGGER.info("Transient error during update, will retry in 15s: %s", err)
                 raise UpdateFailed(retry_after=timedelta(seconds=15)) from err
-            raise
+            self._retry_on_error = False
+            LOGGER.info("Retry also failed, resuming normal poll interval: %s", err)
+            raise UpdateFailed() from err
 
     def update_features(self) -> None:
         """Update the supported features based on the current state."""

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import aiohttp
 from winix import WinixAccount, auth
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 
 from .const import LOGGER, WINIX_DOMAIN
@@ -80,8 +83,13 @@ class WinixManager(DataUpdateCoordinator):
         """Fetch the latest data from the source. This overrides the method in DataUpdateCoordinator."""
 
         LOGGER.info("Updating devices")
-        for device_wrapper in self._device_wrappers:
-            await device_wrapper.update()
+        try:
+            for device_wrapper in self._device_wrappers:
+                await device_wrapper.update()
+        except HomeAssistantError as err:
+            if isinstance(err.__cause__, aiohttp.ClientConnectorDNSError):
+                raise UpdateFailed(retry_after=timedelta(seconds=15)) from err
+            raise
 
     def update_features(self) -> None:
         """Update the supported features based on the current state."""


### PR DESCRIPTION
## Summary

During live testing of PR #158, occasional transient DNS failures were observed:

```
HomeAssistantError: Error communicating with Winix: Cannot connect to host us.api.winix-iot.com:443 ssl:default [Timeout while contacting DNS servers]
```

DNS recovers on its own, but with no retry logic the coordinator waits the full scan interval (30s) before trying again, leaving entities unavailable in the meantime.

## Change

Catch `ClientConnectorDNSError` in `_async_update_data` and raise `UpdateFailed(retry_after=timedelta(seconds=15))`, letting the DataUpdateCoordinator framework retry sooner rather than waiting the full interval.

`ClientConnectorDNSError` is already wrapped into `HomeAssistantError` by the driver, so it's detected via `__cause__`. All other `HomeAssistantError` cases (HTTP errors, timeouts) are re-raised unchanged.

```python
try:
    for device_wrapper in self._device_wrappers:
        await device_wrapper.update()
except HomeAssistantError as err:
    if isinstance(err.__cause__, aiohttp.ClientConnectorDNSError):
        raise UpdateFailed(retry_after=timedelta(seconds=15)) from err
    raise
```

## References

- Discussed in PR #158 comments