### PR TITLE
fix: replace WarrantLite SRP login with USER_PASSWORD_AUTH via boto3

### DIFF
--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -127,10 +127,28 @@ class Helpers:
     def login(username: str, password: str) -> auth.WinixAuthResponse:
         """Log in synchronously."""
 
+        # Use boto3 directly — auth.login() uses WarrantLite's SRP flow which calls
+        # get_secret_hash() and breaks with client_secret=None (new public client has
+        # no secret). USER_PASSWORD_AUTH bypasses SRP entirely.
         try:
-            response = auth.login(username, password)
+            resp = _COGNITO_IDP_CLIENT.initiate_auth(
+                ClientId=auth.COGNITO_APP_CLIENT_ID,
+                AuthFlow="USER_PASSWORD_AUTH",
+                AuthParameters={
+                    "USERNAME": username,
+                    "PASSWORD": password,
+                },
+            )
         except Exception as err:  # pylint: disable=broad-except
             raise WinixException.from_aws_exception(err) from err
+
+        result = resp["AuthenticationResult"]
+        response = auth.WinixAuthResponse(
+            user_id=username,
+            access_token=result["AccessToken"],
+            refresh_token=result["RefreshToken"],
+            id_token=result["IdToken"],
+        )
 
         access_token = response.access_token
         uuid = WinixAccount(access_token).get_uuid()


### PR DESCRIPTION
## Problem

Users are reporting login failures after deploying the v1.5.7 fix:

```
Unexpected error during authentication: An error occurred (NotAuthorizedException)
when calling the RespondToAuthChallenge operation: Incorrect username or password.
```

`RespondToAuthChallenge` is part of Cognito's SRP auth flow — used by `auth.login()` via WarrantLite. The root cause is the same as the one already fixed in `async_refresh_auth`: WarrantLite calls `get_secret_hash()` which breaks when `client_secret=None` (the new public client has no secret). This causes the SRP password verifier to be computed or submitted incorrectly for some accounts.

The failure is not universal — users with existing sessions that re-auth via the stored credentials may not notice it, but any fresh login (new install, reconfigure, or re-auth for affected accounts) hits it.

## Fix

Replace `auth.login()` with a direct boto3 `USER_PASSWORD_AUTH` call — the same pattern already used in `async_refresh_auth` — which bypasses SRP entirely and is not sensitive to the missing client secret.

## References

- Same root cause as the `async_refresh_auth` fix in #158