### PR TITLE
fix: use seconds value for retry_after

### DIFF
--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -20,6 +20,8 @@ from .device_wrapper import WinixDeviceWrapper
 from .driver import WinixTransientError
 from .helpers import Helpers
 
+RETRY_INTERVAL_SECONDS = 15
+
 
 class WinixEntity(CoordinatorEntity):
     """Represents a Winix entity."""
@@ -90,11 +92,15 @@ class WinixManager(DataUpdateCoordinator):
         except WinixTransientError as err:
             if not self._retry_on_error:
                 self._retry_on_error = True
-                LOGGER.info("Transient error during update, will retry in 15s: %s", err)
-                raise UpdateFailed(retry_after=timedelta(seconds=15)) from err
+                LOGGER.info(
+                    "Transient error during update, will retry in %ds: %s",
+                    RETRY_INTERVAL_SECONDS,
+                    err,
+                )
+                raise UpdateFailed(retry_after=RETRY_INTERVAL_SECONDS) from err
             self._retry_on_error = False
             LOGGER.info("Retry also failed, resuming normal poll interval: %s", err)
-            raise UpdateFailed() from err
+            raise UpdateFailed from err
 
     def update_features(self) -> None:
         """Update the supported features based on the current state."""


### PR DESCRIPTION
The value assigned to UpdateFailed exception (in #161) is supposed to be seconds and not timedelta() which was resulting in following exception.

```
2026-04-19 10:04:52.913 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (task: None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 296, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 563, in _async_refresh
    self._schedule_refresh()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 270, in _schedule_refresh
    next_refresh = int(loop.time()) + self._microsecond + update_interval
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'float' and 'datetime.timedelta'
```



To test define this static field on class WinixDriver:  `load_test_counter = 0` and this block to the beginning of `get_state`:

```
        WinixDriver.load_test_counter += 1

        if WinixDriver.load_test_counter == 2:
            raise WinixTransientError(f"{self.device_id} simulated transient error for testing")
```