### PR TITLE
Introduce WinixDriver base class for multi-product support 

### DIFF
--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -25,6 +25,9 @@ ATTR_MODE: Final = "mode"
 ATTR_PLASMA: Final = "plasma"
 ATTR_POWER: Final = "power"
 ATTR_LAST_BRIGHTNESS_LEVEL: Final = "last_brightness_level"
+ATTR_BRIGHTNESS_LEVEL: Final = "brightness_level"
+ATTR_CHILD_LOCK: Final = "child_lock"
+ATTR_AMBIENT_LIGHT: Final = "ambient_light"
 
 SENSOR_AIR_QVALUE: Final = "air_qvalue"
 SENSOR_PM25: Final = "pm2_5"
@@ -33,6 +36,10 @@ SENSOR_FILTER_LIFE: Final = "filter_life"
 
 OFF_VALUE: Final = "off"
 ON_VALUE: Final = "on"
+
+AIR_QUALITY_GOOD: Final = "good"
+AIR_QUALITY_FAIR: Final = "fair"
+AIR_QUALITY_POOR: Final = "poor"
 
 # The service name is the partial name of the method in WinixPurifier
 SERVICE_PLASMAWAVE_ON: Final = "plasmawave_on"

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -170,6 +170,7 @@ class WinixDeviceWrapper:
         """Turn on the purifier."""
         if not self._on:
             self._on = True
+            self._state[ATTR_POWER] = ON_VALUE
 
             self._logger.debug("%s => turned on", self._alias)
             await self._driver.turn_on()
@@ -183,6 +184,7 @@ class WinixDeviceWrapper:
         """Turn off the purifier."""
         if self._on:
             self._on = False
+            self._state[ATTR_POWER] = OFF_VALUE
 
             self._logger.debug("%s => turned off", self._alias)
             await self._driver.turn_off()
@@ -239,6 +241,7 @@ class WinixDeviceWrapper:
 
         await self._driver.child_lock_on()
         self._child_lock_on = True
+        self._state[ATTR_CHILD_LOCK] = ON_VALUE
         return True
 
     async def async_child_lock_off(self) -> bool:
@@ -249,6 +252,7 @@ class WinixDeviceWrapper:
 
         await self._driver.child_lock_off()
         self._child_lock_on = False
+        self._state[ATTR_CHILD_LOCK] = OFF_VALUE
         return True
 
     @property
@@ -266,6 +270,7 @@ class WinixDeviceWrapper:
 
         await self._driver.set_brightness_level(value)
         self._brightness_level = value
+        self._state[ATTR_BRIGHTNESS_LEVEL] = value
         return True
 
     async def async_manual(self) -> None:

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -10,6 +10,8 @@ from .const import (
     AIRFLOW_LOW,
     AIRFLOW_SLEEP,
     ATTR_AIRFLOW,
+    ATTR_BRIGHTNESS_LEVEL,
+    ATTR_CHILD_LOCK,
     ATTR_MODE,
     ATTR_PLASMA,
     ATTR_POWER,
@@ -26,7 +28,7 @@ from .const import (
     Features,
     NumericPresetModes,
 )
-from .driver import ATTR_BRIGHTNESS_LEVEL, ATTR_CHILD_LOCK, WinixDriver
+from .driver import WinixDriver
 
 
 @dataclasses.dataclass

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -28,7 +28,7 @@ from .const import (
     Features,
     NumericPresetModes,
 )
-from .driver import WinixDriver
+from .driver import AirPurifierDriver
 
 
 @dataclasses.dataclass
@@ -59,7 +59,7 @@ class WinixDeviceWrapper:
     ) -> None:
         """Initialize the wrapper."""
 
-        self._driver = WinixDriver(device_stub.id, client, identity_id)
+        self._driver = AirPurifierDriver(device_stub.id, client, identity_id)
 
         # Start as empty object in case fan was operated before it got updated
         self._state = {}

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -101,87 +101,66 @@ class WinixDriver:
 
     async def turn_off(self) -> None:
         """Turn the device off."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_POWER], self.state_keys[ATTR_POWER][OFF_VALUE]
-        )
+        await self.control(ATTR_POWER, OFF_VALUE)
 
     async def turn_on(self) -> None:
         """Turn the device on."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_POWER], self.state_keys[ATTR_POWER][ON_VALUE]
-        )
+        await self.control(ATTR_POWER, ON_VALUE)
 
     async def auto(self) -> None:
         """Set device in auto mode."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_MODE], self.state_keys[ATTR_MODE][MODE_AUTO]
-        )
+        await self.control(ATTR_MODE, MODE_AUTO)
 
     async def manual(self) -> None:
         """Set device in manual mode."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_MODE], self.state_keys[ATTR_MODE][MODE_MANUAL]
-        )
+        await self.control(ATTR_MODE, MODE_MANUAL)
 
     async def child_lock_off(self) -> None:
         """Turn child lock off."""
-        await self._rpc_attr(self.category_keys[ATTR_CHILD_LOCK], "0")
+        await self.control(ATTR_CHILD_LOCK, OFF_VALUE)
 
     async def child_lock_on(self) -> None:
         """Turn child lock on."""
-        await self._rpc_attr(self.category_keys[ATTR_CHILD_LOCK], "1")
+        await self.control(ATTR_CHILD_LOCK, ON_VALUE)
 
     async def set_brightness_level(self, value: int) -> bool:
         """Set brightness level."""
         if not any(e.value == value for e in BrightnessLevel):
             return False
 
-        await self._rpc_attr(self.category_keys[ATTR_BRIGHTNESS_LEVEL], value)
+        await self._rpc_attr(self.category_keys[ATTR_BRIGHTNESS_LEVEL], str(value))
         return True
 
     async def plasmawave_off(self) -> None:
         """Turn plasmawave off."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_PLASMA], self.state_keys[ATTR_PLASMA][OFF_VALUE]
-        )
+        await self.control(ATTR_PLASMA, OFF_VALUE)
 
     async def plasmawave_on(self) -> None:
         """Turn plasmawave on."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_PLASMA], self.state_keys[ATTR_PLASMA][ON_VALUE]
-        )
+        await self.control(ATTR_PLASMA, ON_VALUE)
 
     async def low(self) -> None:
         """Set speed low."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_LOW]
-        )
+        await self.control(ATTR_AIRFLOW, AIRFLOW_LOW)
 
     async def medium(self) -> None:
         """Set speed medium."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_MEDIUM]
-        )
+        await self.control(ATTR_AIRFLOW, AIRFLOW_MEDIUM)
 
     async def high(self) -> None:
         """Set speed high."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_HIGH]
-        )
+        await self.control(ATTR_AIRFLOW, AIRFLOW_HIGH)
 
     async def turbo(self) -> None:
         """Set speed turbo."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_TURBO]
-        )
+        await self.control(ATTR_AIRFLOW, AIRFLOW_TURBO)
 
     async def sleep(self) -> None:
         """Set device in sleep mode."""
-        await self._rpc_attr(
-            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_SLEEP]
-        )
+        await self.control(ATTR_AIRFLOW, AIRFLOW_SLEEP)
 
     async def _rpc_attr(self, attr: str, value: str) -> None:
+        """Make a raw API call with the given attribute code and value."""
         LOGGER.debug("_rpc_attr attribute=%s, value=%s", attr, value)
 
         try:
@@ -204,6 +183,13 @@ class WinixDriver:
             raise HomeAssistantError(f"Error communicating with Winix: {err}") from err
         except TimeoutError as err:
             raise HomeAssistantError("Timeout communicating with Winix") from err
+
+    async def control(self, category: str, state_key: str) -> None:
+        """Control the device using semantic category/state names."""
+        await self._rpc_attr(
+            self.category_keys[category],
+            self.state_keys[category][state_key],
+        )
 
     async def get_filter_life(self) -> int | None:
         """Get the total filter life.

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -54,110 +54,22 @@ class BrightnessLevel(Enum):
 
 
 class WinixDriver:
-    """WinixDevice driver."""
+    """Base Winix driver."""
 
     # pylint: disable=line-too-long
     CTRL_URL = "https://us.api.winix-iot.com/common/control/devices/{deviceid}/{identityid}/{attribute}:{value}"
     STATE_URL = "https://us.api.winix-iot.com/common/event/sttus/devices/{deviceid}"
-    PARAM_URL = "https://us.api.winix-iot.com/common/event/param/devices/{deviceid}"
 
-    category_keys = {
-        ATTR_POWER: "A02",
-        ATTR_MODE: "A03",
-        ATTR_AIRFLOW: "A04",
-        ATTR_AIR_AQI: "A05",
-        ATTR_PLASMA: "A07",
-        ATTR_CHILD_LOCK: "A08",
-        ATTR_BRIGHTNESS_LEVEL: "A16",
-        ATTR_FILTER_HOUR: "A21",
-        ATTR_AIR_QUALITY: "S07",
-        ATTR_AIR_QVALUE: "S08",
-        ATTR_PM25: "S04",
-        ATTR_AMBIENT_LIGHT: "S14",
-    }
-
-    state_keys = {
-        ATTR_POWER: {OFF_VALUE: "0", ON_VALUE: "1"},
-        ATTR_MODE: {MODE_AUTO: "01", MODE_MANUAL: "02"},
-        ATTR_AIRFLOW: {
-            AIRFLOW_LOW: "01",
-            AIRFLOW_MEDIUM: "02",
-            AIRFLOW_HIGH: "03",
-            AIRFLOW_TURBO: "05",
-            AIRFLOW_SLEEP: "06",
-        },
-        ATTR_CHILD_LOCK: {OFF_VALUE: "0", ON_VALUE: "1"},
-        ATTR_PLASMA: {OFF_VALUE: "0", ON_VALUE: "1"},
-        ATTR_AIR_QUALITY: {AIR_QUALITY_GOOD: "01", AIR_QUALITY_FAIR: "02", AIR_QUALITY_POOR: "03"},
-    }
+    category_keys: dict[str, str] | None = None
+    state_keys: dict[str, dict[str, str]] | None = None
 
     def __init__(
         self, device_id: str, client: aiohttp.ClientSession, identity_id: str
     ) -> None:
-        """Create an instance of WinixDevice."""
+        """Create an instance of WinixDriver."""
         self.device_id = device_id
         self._client = client
         self._identity_id = identity_id
-
-    async def turn_off(self) -> None:
-        """Turn the device off."""
-        await self.control(ATTR_POWER, OFF_VALUE)
-
-    async def turn_on(self) -> None:
-        """Turn the device on."""
-        await self.control(ATTR_POWER, ON_VALUE)
-
-    async def auto(self) -> None:
-        """Set device in auto mode."""
-        await self.control(ATTR_MODE, MODE_AUTO)
-
-    async def manual(self) -> None:
-        """Set device in manual mode."""
-        await self.control(ATTR_MODE, MODE_MANUAL)
-
-    async def child_lock_off(self) -> None:
-        """Turn child lock off."""
-        await self.control(ATTR_CHILD_LOCK, OFF_VALUE)
-
-    async def child_lock_on(self) -> None:
-        """Turn child lock on."""
-        await self.control(ATTR_CHILD_LOCK, ON_VALUE)
-
-    async def set_brightness_level(self, value: int) -> bool:
-        """Set brightness level."""
-        if not any(e.value == value for e in BrightnessLevel):
-            return False
-
-        await self._rpc_attr(self.category_keys[ATTR_BRIGHTNESS_LEVEL], str(value))
-        return True
-
-    async def plasmawave_off(self) -> None:
-        """Turn plasmawave off."""
-        await self.control(ATTR_PLASMA, OFF_VALUE)
-
-    async def plasmawave_on(self) -> None:
-        """Turn plasmawave on."""
-        await self.control(ATTR_PLASMA, ON_VALUE)
-
-    async def low(self) -> None:
-        """Set speed low."""
-        await self.control(ATTR_AIRFLOW, AIRFLOW_LOW)
-
-    async def medium(self) -> None:
-        """Set speed medium."""
-        await self.control(ATTR_AIRFLOW, AIRFLOW_MEDIUM)
-
-    async def high(self) -> None:
-        """Set speed high."""
-        await self.control(ATTR_AIRFLOW, AIRFLOW_HIGH)
-
-    async def turbo(self) -> None:
-        """Set speed turbo."""
-        await self.control(ATTR_AIRFLOW, AIRFLOW_TURBO)
-
-    async def sleep(self) -> None:
-        """Set device in sleep mode."""
-        await self.control(ATTR_AIRFLOW, AIRFLOW_SLEEP)
 
     async def _rpc_attr(self, attr: str, value: str) -> None:
         """Make a raw API call with the given attribute code and value."""
@@ -191,62 +103,12 @@ class WinixDriver:
             self.state_keys[category][state_key],
         )
 
-    async def get_filter_life(self) -> int | None:
-        """Get the total filter life.
-
-        This raises HomeAssistantError on communication errors
-        """
-        try:
-            response = await self._client.get(
-                self.PARAM_URL.format(deviceid=self.device_id)
-            )
-            response.raise_for_status()
-            json = await response.json()
-        except aiohttp.ClientResponseError as err:
-            raise HomeAssistantError(
-                f"Failed to download data: HTTP {err.status}"
-            ) from err
-        except aiohttp.ClientError as err:
-            raise HomeAssistantError(f"Error communicating with Winix: {err}") from err
-        except TimeoutError as err:
-            raise HomeAssistantError("Timeout communicating with Winix") from err
-
-        # pylint: disable=pointless-string-statement
-        """
-        {
-            'statusCode': 200, 'headers': {'resultCode': 'S100', 'resultMessage': ''},
-            'body': {
-                'deviceId': '847207352CE0_364yr8i989', 'totalCnt': 1,
-                'data': [
-                    {
-                        'apiNo': 'A240', 'apiGroup': '004', 'modelId': 'C545', 'attributes': {'P01': '6480'}
-                    }
-                ]
-            }
-        }
-        """
-
-        headers = json.get("headers", {})
-        if headers.get("resultMessage") == "no data":
-            LOGGER.info("No filter life data received")
-            return None
-
-        try:
-            attributes = json["body"]["data"][0]["attributes"]
-            if attributes:
-                return int(attributes["P01"])
-        except Exception:  # pylint: disable=broad-except # noqa: BLE001
-            return None
-
     async def get_state(self) -> dict[str, str | int]:
         """Get device state.
 
         This raises HomeAssistantError on communication errors, but returns an empty dict if the response is successfully received but doesn't contain expected data.
         This allows callers to handle missing data without crashing.
         """
-
-        # All devices seem to have max 9 months filter life so don't need to call this API.
-        # await self.get_filter_life()
 
         try:
             response = await self._client.get(
@@ -315,3 +177,150 @@ class WinixDriver:
                             continue
 
         return output
+
+
+class AirPurifierDriver(WinixDriver):
+    """Winix Air Purifier driver."""
+
+    # pylint: disable=line-too-long
+    PARAM_URL = "https://us.api.winix-iot.com/common/event/param/devices/{deviceid}"
+
+    category_keys = {
+        ATTR_POWER: "A02",
+        ATTR_MODE: "A03",
+        ATTR_AIRFLOW: "A04",
+        ATTR_AIR_AQI: "A05",
+        ATTR_PLASMA: "A07",
+        ATTR_CHILD_LOCK: "A08",
+        ATTR_BRIGHTNESS_LEVEL: "A16",
+        ATTR_FILTER_HOUR: "A21",
+        ATTR_AIR_QUALITY: "S07",
+        ATTR_AIR_QVALUE: "S08",
+        ATTR_PM25: "S04",
+        ATTR_AMBIENT_LIGHT: "S14",
+    }
+
+    state_keys = {
+        ATTR_POWER: {OFF_VALUE: "0", ON_VALUE: "1"},
+        ATTR_MODE: {MODE_AUTO: "01", MODE_MANUAL: "02"},
+        ATTR_AIRFLOW: {
+            AIRFLOW_LOW: "01",
+            AIRFLOW_MEDIUM: "02",
+            AIRFLOW_HIGH: "03",
+            AIRFLOW_TURBO: "05",
+            AIRFLOW_SLEEP: "06",
+        },
+        ATTR_CHILD_LOCK: {OFF_VALUE: "0", ON_VALUE: "1"},
+        ATTR_PLASMA: {OFF_VALUE: "0", ON_VALUE: "1"},
+        ATTR_AIR_QUALITY: {AIR_QUALITY_GOOD: "01", AIR_QUALITY_FAIR: "02", AIR_QUALITY_POOR: "03"},
+    }
+
+    async def turn_off(self) -> None:
+        """Turn the device off."""
+        await self.control(ATTR_POWER, OFF_VALUE)
+
+    async def turn_on(self) -> None:
+        """Turn the device on."""
+        await self.control(ATTR_POWER, ON_VALUE)
+
+    async def auto(self) -> None:
+        """Set device in auto mode."""
+        await self.control(ATTR_MODE, MODE_AUTO)
+
+    async def manual(self) -> None:
+        """Set device in manual mode."""
+        await self.control(ATTR_MODE, MODE_MANUAL)
+
+    async def child_lock_off(self) -> None:
+        """Turn child lock off."""
+        await self.control(ATTR_CHILD_LOCK, OFF_VALUE)
+
+    async def child_lock_on(self) -> None:
+        """Turn child lock on."""
+        await self.control(ATTR_CHILD_LOCK, ON_VALUE)
+
+    async def set_brightness_level(self, value: int) -> bool:
+        """Set brightness level."""
+        if not any(e.value == value for e in BrightnessLevel):
+            return False
+
+        await self._rpc_attr(self.category_keys[ATTR_BRIGHTNESS_LEVEL], str(value))
+        return True
+
+    async def plasmawave_off(self) -> None:
+        """Turn plasmawave off."""
+        await self.control(ATTR_PLASMA, OFF_VALUE)
+
+    async def plasmawave_on(self) -> None:
+        """Turn plasmawave on."""
+        await self.control(ATTR_PLASMA, ON_VALUE)
+
+    async def low(self) -> None:
+        """Set speed low."""
+        await self.control(ATTR_AIRFLOW, AIRFLOW_LOW)
+
+    async def medium(self) -> None:
+        """Set speed medium."""
+        await self.control(ATTR_AIRFLOW, AIRFLOW_MEDIUM)
+
+    async def high(self) -> None:
+        """Set speed high."""
+        await self.control(ATTR_AIRFLOW, AIRFLOW_HIGH)
+
+    async def turbo(self) -> None:
+        """Set speed turbo."""
+        await self.control(ATTR_AIRFLOW, AIRFLOW_TURBO)
+
+    async def sleep(self) -> None:
+        """Set device in sleep mode."""
+        await self.control(ATTR_AIRFLOW, AIRFLOW_SLEEP)
+
+    async def get_filter_life(self) -> int | None:
+        """Get the total filter life.
+
+        Not called from get_state() — all devices seem to have a max
+        9-month filter life, so polling this API is unnecessary.
+
+        This raises HomeAssistantError on communication errors
+        """
+        try:
+            response = await self._client.get(
+                self.PARAM_URL.format(deviceid=self.device_id)
+            )
+            response.raise_for_status()
+            json = await response.json()
+        except aiohttp.ClientResponseError as err:
+            raise HomeAssistantError(
+                f"Failed to download data: HTTP {err.status}"
+            ) from err
+        except aiohttp.ClientError as err:
+            raise HomeAssistantError(f"Error communicating with Winix: {err}") from err
+        except TimeoutError as err:
+            raise HomeAssistantError("Timeout communicating with Winix") from err
+
+        # pylint: disable=pointless-string-statement
+        """
+        {
+            'statusCode': 200, 'headers': {'resultCode': 'S100', 'resultMessage': ''},
+            'body': {
+                'deviceId': '847207352CE0_364yr8i989', 'totalCnt': 1,
+                'data': [
+                    {
+                        'apiNo': 'A240', 'apiGroup': '004', 'modelId': 'C545', 'attributes': {'P01': '6480'}
+                    }
+                ]
+            }
+        }
+        """
+
+        headers = json.get("headers", {})
+        if headers.get("resultMessage") == "no data":
+            LOGGER.info("No filter life data received")
+            return None
+
+        try:
+            attributes = json["body"]["data"][0]["attributes"]
+            if attributes:
+                return int(attributes["P01"])
+        except Exception:  # pylint: disable=broad-except # noqa: BLE001
+            return None

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -3,23 +3,44 @@
 from __future__ import annotations
 
 from enum import Enum, unique
-from typing import Final
 
 import aiohttp
 
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import ATTR_PM25, LOGGER
+from .const import (
+    AIR_QUALITY_FAIR,
+    AIR_QUALITY_GOOD,
+    AIR_QUALITY_POOR,
+    AIRFLOW_HIGH,
+    AIRFLOW_LOW,
+    AIRFLOW_MEDIUM,
+    AIRFLOW_SLEEP,
+    AIRFLOW_TURBO,
+    ATTR_AIR_AQI,
+    ATTR_AIR_QUALITY,
+    ATTR_AIR_QVALUE,
+    ATTR_AIRFLOW,
+    ATTR_AMBIENT_LIGHT,
+    ATTR_BRIGHTNESS_LEVEL,
+    ATTR_CHILD_LOCK,
+    ATTR_FILTER_HOUR,
+    ATTR_MODE,
+    ATTR_PLASMA,
+    ATTR_PM25,
+    ATTR_POWER,
+    LOGGER,
+    MODE_AUTO,
+    MODE_MANUAL,
+    OFF_VALUE,
+    ON_VALUE,
+)
 
 # Modified from https://github.com/hfern/winix to support async operations
 
 
 class WinixTransientError(HomeAssistantError):
     """Raised for transient network errors that may resolve on retry."""
-
-
-ATTR_BRIGHTNESS_LEVEL: Final = "brightness_level"
-ATTR_CHILD_LOCK: Final = "child_lock"
 
 
 @unique
@@ -41,33 +62,33 @@ class WinixDriver:
     PARAM_URL = "https://us.api.winix-iot.com/common/event/param/devices/{deviceid}"
 
     category_keys = {
-        "power": "A02",
-        "mode": "A03",
-        "airflow": "A04",
-        "aqi": "A05",
-        "plasma": "A07",
-        ATTR_BRIGHTNESS_LEVEL: "A16",
+        ATTR_POWER: "A02",
+        ATTR_MODE: "A03",
+        ATTR_AIRFLOW: "A04",
+        ATTR_AIR_AQI: "A05",
+        ATTR_PLASMA: "A07",
         ATTR_CHILD_LOCK: "A08",
-        "filter_hour": "A21",
-        "air_quality": "S07",
-        "air_qvalue": "S08",
+        ATTR_BRIGHTNESS_LEVEL: "A16",
+        ATTR_FILTER_HOUR: "A21",
+        ATTR_AIR_QUALITY: "S07",
+        ATTR_AIR_QVALUE: "S08",
         ATTR_PM25: "S04",
-        "ambient_light": "S14",
+        ATTR_AMBIENT_LIGHT: "S14",
     }
 
     state_keys = {
-        "power": {"off": "0", "on": "1"},
-        "mode": {"auto": "01", "manual": "02"},
-        "airflow": {
-            "low": "01",
-            "medium": "02",
-            "high": "03",
-            "turbo": "05",
-            "sleep": "06",
+        ATTR_POWER: {OFF_VALUE: "0", ON_VALUE: "1"},
+        ATTR_MODE: {MODE_AUTO: "01", MODE_MANUAL: "02"},
+        ATTR_AIRFLOW: {
+            AIRFLOW_LOW: "01",
+            AIRFLOW_MEDIUM: "02",
+            AIRFLOW_HIGH: "03",
+            AIRFLOW_TURBO: "05",
+            AIRFLOW_SLEEP: "06",
         },
-        ATTR_CHILD_LOCK: {"off": "0", "on": "1"},
-        "plasma": {"off": "0", "on": "1"},
-        "air_quality": {"good": "01", "fair": "02", "poor": "03"},
+        ATTR_CHILD_LOCK: {OFF_VALUE: "0", ON_VALUE: "1"},
+        ATTR_PLASMA: {OFF_VALUE: "0", ON_VALUE: "1"},
+        ATTR_AIR_QUALITY: {AIR_QUALITY_GOOD: "01", AIR_QUALITY_FAIR: "02", AIR_QUALITY_POOR: "03"},
     }
 
     def __init__(
@@ -81,25 +102,25 @@ class WinixDriver:
     async def turn_off(self) -> None:
         """Turn the device off."""
         await self._rpc_attr(
-            self.category_keys["power"], self.state_keys["power"]["off"]
+            self.category_keys[ATTR_POWER], self.state_keys[ATTR_POWER][OFF_VALUE]
         )
 
     async def turn_on(self) -> None:
         """Turn the device on."""
         await self._rpc_attr(
-            self.category_keys["power"], self.state_keys["power"]["on"]
+            self.category_keys[ATTR_POWER], self.state_keys[ATTR_POWER][ON_VALUE]
         )
 
     async def auto(self) -> None:
         """Set device in auto mode."""
         await self._rpc_attr(
-            self.category_keys["mode"], self.state_keys["mode"]["auto"]
+            self.category_keys[ATTR_MODE], self.state_keys[ATTR_MODE][MODE_AUTO]
         )
 
     async def manual(self) -> None:
         """Set device in manual mode."""
         await self._rpc_attr(
-            self.category_keys["mode"], self.state_keys["mode"]["manual"]
+            self.category_keys[ATTR_MODE], self.state_keys[ATTR_MODE][MODE_MANUAL]
         )
 
     async def child_lock_off(self) -> None:
@@ -121,43 +142,43 @@ class WinixDriver:
     async def plasmawave_off(self) -> None:
         """Turn plasmawave off."""
         await self._rpc_attr(
-            self.category_keys["plasma"], self.state_keys["plasma"]["off"]
+            self.category_keys[ATTR_PLASMA], self.state_keys[ATTR_PLASMA][OFF_VALUE]
         )
 
     async def plasmawave_on(self) -> None:
         """Turn plasmawave on."""
         await self._rpc_attr(
-            self.category_keys["plasma"], self.state_keys["plasma"]["on"]
+            self.category_keys[ATTR_PLASMA], self.state_keys[ATTR_PLASMA][ON_VALUE]
         )
 
     async def low(self) -> None:
         """Set speed low."""
         await self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["low"]
+            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_LOW]
         )
 
     async def medium(self) -> None:
         """Set speed medium."""
         await self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["medium"]
+            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_MEDIUM]
         )
 
     async def high(self) -> None:
         """Set speed high."""
         await self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["high"]
+            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_HIGH]
         )
 
     async def turbo(self) -> None:
         """Set speed turbo."""
         await self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["turbo"]
+            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_TURBO]
         )
 
     async def sleep(self) -> None:
         """Set device in sleep mode."""
         await self._rpc_attr(
-            self.category_keys["airflow"], self.state_keys["airflow"]["sleep"]
+            self.category_keys[ATTR_AIRFLOW], self.state_keys[ATTR_AIRFLOW][AIRFLOW_SLEEP]
         )
 
     async def _rpc_attr(self, attr: str, value: str) -> None:

--- a/custom_components/winix/select.py
+++ b/custom_components/winix/select.py
@@ -52,7 +52,7 @@ SELECT_DESCRIPTIONS: Final[tuple[WinixSelectEntityDescription, ...]] = (
         exists_fn=lambda device: device.features.supports_brightness_level,
         icon="mdi:brightness-6",
         key="brightness_level",
-        name="Brightness level",
+        name="Brightness Level",
         options=BRIGHTNESS_OPTIONS,
         select_option_fn=lambda device, value: device.async_set_brightness_level(
             parse_brightness_level(value)

--- a/custom_components/winix/switch.py
+++ b/custom_components/winix/switch.py
@@ -33,7 +33,7 @@ SWITCH_DESCRIPTIONS: Final[tuple[WinixSwitchEntityDescription, ...]] = (
         key="child_lock",
         is_on=lambda device: device.is_child_lock_on,
         exists_fn=lambda device: device.features.supports_child_lock,
-        name="Child lock",
+        name="Child Lock",
         on_fn=lambda device: device.async_child_lock_on(),
         off_fn=lambda device: device.async_child_lock_off(),
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 
 from custom_components.winix.device_wrapper import MyWinixDeviceStub, WinixDeviceWrapper
-from custom_components.winix.driver import WinixDriver
+from custom_components.winix.driver import AirPurifierDriver
 
 from .common import TEST_DEVICE_ID  # noqa: TID251
 
@@ -86,17 +86,17 @@ def mock_device_wrapper() -> WinixDeviceWrapper:
 
 
 @pytest.fixture
-def mock_driver() -> WinixDriver:
-    """Return a mocked WinixDriver instance."""
+def mock_driver() -> AirPurifierDriver:
+    """Return a mocked AirPurifierDriver instance."""
     client = Mock()
     device_id = "device_1"
     identity_id = "test_identity_id"
-    return WinixDriver(device_id, client, identity_id)
+    return AirPurifierDriver(device_id, client, identity_id)
 
 
 @pytest.fixture
-def mock_driver_with_payload(request: pytest.FixtureRequest) -> WinixDriver:
-    """Return a mocked WinixDriver instance."""
+def mock_driver_with_payload(request: pytest.FixtureRequest) -> AirPurifierDriver:
+    """Return a mocked AirPurifierDriver instance."""
 
     json_value = {"body": {"data": [{"attributes": request.param}]}}
 
@@ -109,4 +109,4 @@ def mock_driver_with_payload(request: pytest.FixtureRequest) -> WinixDriver:
 
     device_id = "device_1"
     identity_id = "test_identity_id"
-    return WinixDriver(device_id, client, identity_id)
+    return AirPurifierDriver(device_id, client, identity_id)

--- a/tests/test_device_wrapper.py
+++ b/tests/test_device_wrapper.py
@@ -28,7 +28,7 @@ from custom_components.winix.device_wrapper import WinixDeviceWrapper
 
 from .common import build_mock_wrapper  # noqa: TID251
 
-WinixDriver_TypeName = "custom_components.winix.driver.WinixDriver"
+AirPurifierDriver_TypeName = "custom_components.winix.driver.AirPurifierDriver"
 
 
 @pytest.mark.parametrize(
@@ -81,7 +81,7 @@ async def test_wrapper_update(
     """Tests device wrapper states."""
 
     with patch(
-        f"{WinixDriver_TypeName}.get_state",
+        f"{AirPurifierDriver_TypeName}.get_state",
         AsyncMock(return_value=mock_state),
     ) as get_state:
         wrapper = build_mock_wrapper()
@@ -98,7 +98,7 @@ async def test_wrapper_update(
 
 async def test_async_ensure_on() -> None:
     """Test ensuring device is on."""
-    with patch(f"{WinixDriver_TypeName}.turn_on") as turn_on:
+    with patch(f"{AirPurifierDriver_TypeName}.turn_on") as turn_on:
         wrapper = build_mock_wrapper()
         assert not wrapper.is_on  # initially off
 
@@ -113,8 +113,8 @@ async def test_async_ensure_on() -> None:
 async def test_async_turn_off() -> None:
     """Test turning off."""
     with (
-        patch(f"{WinixDriver_TypeName}.turn_on") as turn_on,
-        patch(f"{WinixDriver_TypeName}.turn_off") as turn_off,
+        patch(f"{AirPurifierDriver_TypeName}.turn_on") as turn_on,
+        patch(f"{AirPurifierDriver_TypeName}.turn_off") as turn_off,
     ):
         wrapper = build_mock_wrapper()
         assert not wrapper.is_on  # initially off
@@ -155,7 +155,7 @@ async def test_async_auto() -> None:
     """Test setting auto mode."""
 
     # async_auto does not need the device to be turned on
-    with patch(f"{WinixDriver_TypeName}.auto") as auto:
+    with patch(f"{AirPurifierDriver_TypeName}.auto") as auto:
         wrapper = build_mock_wrapper()
 
         await wrapper.async_auto()
@@ -176,8 +176,8 @@ async def test_async_plasmawave_on_off() -> None:
 
     # async_plasmawave does not need the device to be turned on
     with (
-        patch(f"{WinixDriver_TypeName}.plasmawave_on") as plasmawave_on,
-        patch(f"{WinixDriver_TypeName}.plasmawave_off") as plasmawave_off,
+        patch(f"{AirPurifierDriver_TypeName}.plasmawave_on") as plasmawave_on,
+        patch(f"{AirPurifierDriver_TypeName}.plasmawave_off") as plasmawave_off,
     ):
         wrapper = build_mock_wrapper()
 
@@ -207,7 +207,7 @@ async def test_async_manual() -> None:
     """Test setting manual mode."""
 
     # async_manual does not need the device to be turned on
-    with patch(f"{WinixDriver_TypeName}.manual") as manual:
+    with patch(f"{AirPurifierDriver_TypeName}.manual") as manual:
         wrapper = build_mock_wrapper()
 
         await wrapper.async_manual()
@@ -228,7 +228,7 @@ async def test_async_sleep() -> None:
     """Test setting sleep mode."""
 
     # async_sleep does not need the device to be turned on
-    with patch(f"{WinixDriver_TypeName}.sleep") as sleep:
+    with patch(f"{AirPurifierDriver_TypeName}.sleep") as sleep:
         wrapper = build_mock_wrapper()
 
         await wrapper.async_sleep()
@@ -249,10 +249,10 @@ async def test_async_set_speed() -> None:
     """Test setting speed."""
 
     with (
-        patch(f"{WinixDriver_TypeName}.turn_on"),
-        patch(f"{WinixDriver_TypeName}.manual"),
-        patch(f"{WinixDriver_TypeName}.high") as high_speed,
-        patch(f"{WinixDriver_TypeName}.low") as low_speed,
+        patch(f"{AirPurifierDriver_TypeName}.turn_on"),
+        patch(f"{AirPurifierDriver_TypeName}.manual"),
+        patch(f"{AirPurifierDriver_TypeName}.high") as high_speed,
+        patch(f"{AirPurifierDriver_TypeName}.low") as low_speed,
     ):
         wrapper = build_mock_wrapper()
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,10 +1,10 @@
-"""Test WinixDevice component."""
+"""Test WinixDriver component."""
 
 from unittest.mock import patch
 
 import pytest
 
-from custom_components.winix.driver import WinixDriver
+from custom_components.winix.driver import AirPurifierDriver
 
 
 @patch("custom_components.winix.driver.WinixDriver._rpc_attr")
@@ -30,8 +30,8 @@ async def test_turn_off(mock_rpc_attr, mock_driver, method, category, value) -> 
     await getattr(mock_driver, method)()
     assert mock_rpc_attr.call_count == 1
     assert mock_rpc_attr.call_args[0] == (
-        WinixDriver.category_keys[category],
-        WinixDriver.state_keys[category][value],
+        AirPurifierDriver.category_keys[category],
+        AirPurifierDriver.state_keys[category][value],
     )
 
 
@@ -46,7 +46,7 @@ async def test_turn_off(mock_rpc_attr, mock_driver, method, category, value) -> 
     indirect=["mock_driver_with_payload"],
 )
 async def test_get_state(mock_driver_with_payload, expected) -> None:
-    """Test get_state."""
+    """Test get_state for AirPurifierDriver."""
 
     # payload = {"A02": "0"}  # "A02" represents "power" and "0" means "off"
 


### PR DESCRIPTION
Related Issue, PR: #151, #154

This is the first PR splitting PR #154. It contains a few minor fixes and refactors, and the most important change is the last commit. That commit restructures WinixDriver as a shared base class and extracts air-purifier-specific logic into an AirPurifierDriver subclass. This lays the groundwork for adding a DehumidifierDriver later by inheriting the shared HTTP transport and response-parsing logic, rather than adding product-type conditionals inside WinixDriver.


Test Results:

``` bash
$ uv run --python 3.13 --with pytest-homeassistant-custom-component --with winix --with pycryptodome pytest tests/ -p asyncio --asyncio-mode=auto
Test session starts (platform: linux, Python 3.13.7, pytest 9.0.0, pytest-sugar 1.0.0)
rootdir: /home/kyet/ws/winix
plugins: asyncio-1.3.0, pytest_freezer-0.4.9, github-actions-annotate-failures-0.3.0, aiohttp-1.1.0, syrupy-5.0.0, xdist-3.8.0, timeout-2.4.0, cov-7.0.0, sugar-1.0.0, respx-0.22.0, requests-mock-1.12.1, unordered-0.7.0, anyio-4.13.0, homeassistant-custom-component-0.13.316, picked-0.5.1, socket-0.7.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 80 items

 tests/test_config_flow.py ✓✓✓✓                                                                                5% ▌
 tests/test_device_wrapper.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                       36% ███▋
 tests/test_driver.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                         55% █████▌
 tests/test_fan.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                            94% █████████▍
 tests/test_sensor.py ✓✓✓✓✓                                                                                  100% ██████████

Results (0.63s):
      80 passed
```