### PR TITLE
fix: persist identity_id and harden auth state handling

### DIFF
--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 from typing import Final
 
 from awesomeversion import AwesomeVersion
-from winix import auth
 
 from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
@@ -25,6 +24,7 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 
+from .cloud import WinixAuthResponse
 from .const import (
     FAN_SERVICES,
     LOGGER,
@@ -37,7 +37,7 @@ from .const import (
 from .helpers import Helpers, WinixException
 from .manager import WinixManager
 
-type WinixConfigEntry = ConfigEntry[WinixManager]
+WinixConfigEntry = ConfigEntry[WinixManager]
 
 SUPPORTED_PLATFORMS = [Platform.FAN, Platform.SENSOR, Platform.SELECT, Platform.SWITCH]
 DEFAULT_SCAN_INTERVAL: Final = 30
@@ -62,18 +62,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: WinixConfigEntry) -> boo
     user_input = entry.data
 
     auth_response_data = user_input.get(WINIX_AUTH_RESPONSE)
-    auth_response = (
-        auth_response_data
-        if isinstance(auth_response_data, auth.WinixAuthResponse)
-        else auth.WinixAuthResponse(**auth_response_data)
-    )
+    auth_response = WinixAuthResponse.from_dict(auth_response_data)
 
     if not auth_response:
         raise ConfigEntryAuthFailed(
             "No authentication data found. Please reconfigure the integration."
         )
 
-    # Grab the client once and pass it around
+    if not auth_response.identity_id:
+        try:
+            auth_response = await Helpers.async_refresh_auth(
+                hass, user_input[CONF_USERNAME], auth_response
+            )
+        except WinixException:
+            auth_response = await Helpers.async_login(
+                hass, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            )
+
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**user_input, WINIX_AUTH_RESPONSE: auth_response.as_dict()},
+        )
+
     client = aiohttp_client.async_get_clientsession(hass)
 
     manager = WinixManager(hass, entry, auth_response, DEFAULT_SCAN_INTERVAL, client)
@@ -81,7 +91,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: WinixConfigEntry) -> boo
         hass, manager, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
     )
     if new_auth_response is not None:
-        # Copy over new values
         LOGGER.debug(
             "access_token %s",
             "changed"
@@ -104,15 +113,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: WinixConfigEntry) -> boo
         auth_response.access_token = new_auth_response.access_token
         auth_response.refresh_token = new_auth_response.refresh_token
         auth_response.id_token = new_auth_response.id_token
+        auth_response.identity_id = new_auth_response.identity_id
+        auth_response.expires_at = new_auth_response.expires_at
 
-        # Update tokens into entry.data
         hass.config_entries.async_update_entry(
             entry,
-            data={**user_input, WINIX_AUTH_RESPONSE: auth_response},
+            data={**user_input, WINIX_AUTH_RESPONSE: auth_response.as_dict()},
         )
 
     await manager.async_config_entry_first_refresh()
-    manager.update_features()  # Update features after the first refresh to ensure we have the latest state
+    manager.update_features()
 
     entry.runtime_data = manager
     await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
@@ -123,20 +133,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: WinixConfigEntry) -> boo
 
 async def async_prepare_devices(
     hass: HomeAssistant, manager: WinixManager, username: str, password: str
-) -> auth.WinixAuthResponse | None:
+) -> WinixAuthResponse | None:
     """Prepare devices asynchronously. Returns new auth response if re-login was performed.
 
     Raises ConfigEntryAuthFailed or ConfigEntryNotReady.
     """
-    new_auth_response: auth.WinixAuthResponse = None
+    new_auth_response: WinixAuthResponse = None
 
     try:
         await manager.prepare_devices_wrappers()
     except WinixException as err:
-        # 900:MULTI LOGIN: Same credentials were used to login elwsewhere. We need to
-        # login again and get new tokens.
-        # 400:The user is not valid.
-
         if err.result_code in ("900", "400", "NotAuthorizedException"):
             LOGGER.info(
                 "Failed to get device list (code=%s, message=%s), reauthenticating with stored credentials",
@@ -145,7 +151,6 @@ async def async_prepare_devices(
             )
 
             try:
-                # Avoid blocking the event loop (https://developers.home-assistant.io/docs/asyncio_blocking_operations)
                 new_auth_response = await hass.async_add_executor_job(
                     Helpers.login, username, password
                 )
@@ -154,10 +159,9 @@ async def async_prepare_devices(
 
             LOGGER.info("Reauthenticating successful, getting device list again")
 
-            # Try preparing device wrappers again with new auth response
             try:
                 await manager.prepare_devices_wrappers(
-                    new_auth_response.access_token, new_auth_response.id_token
+                    new_auth_response.access_token, new_auth_response.identity_id
                 )
             except WinixException as err_retry:
                 raise ConfigEntryAuthFailed(
@@ -184,7 +188,6 @@ def setup_hass_services(hass: HomeAssistant) -> None:
         device_registry = dr.async_get(hass)
         entity_registry = er.async_get(hass)
 
-        # Using set to avoid duplicates
         entity_ids = set()
         device_ids = set()
 
@@ -236,6 +239,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(
         entry, SUPPORTED_PLATFORMS
     )
+    if unload_ok:
+        hass.data.pop(WINIX_DOMAIN, None)
 
     other_loaded_entries = [
         _entry
@@ -243,7 +248,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if _entry.entry_id != entry.entry_id
     ]
     if not other_loaded_entries:
-        # If this is the last loaded instance, then unregister services
         hass.services.async_remove(WINIX_DOMAIN, SERVICE_REMOVE_STALE_ENTITIES)
 
         for service_name in FAN_SERVICES:

--- a/custom_components/winix/cloud.py
+++ b/custom_components/winix/cloud.py
@@ -1,0 +1,153 @@
+"""Winix cloud authentication and session helpers."""
+
+from __future__ import annotations
+
+from binascii import crc32
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
+from jose import jwt
+from warrant_lite import WarrantLite
+
+COGNITO_APP_CLIENT_ID = "5rjk59c5tt7k9g8gpj0vd2qfg9"
+COGNITO_USER_POOL_ID = "us-east-1_Ofd50EosD"
+COGNITO_REGION = "us-east-1"
+IDENTITY_POOL_ID = "us-east-1:84008e15-d6af-4698-8646-66d05c1abe8b"
+MOBILE_APP_VERSION = "1.5.7"
+MOBILE_MODEL = "SM-G988B"
+COGNITO_LOGINS_PROVIDER = (
+    f"cognito-idp.{COGNITO_REGION}.amazonaws.com/{COGNITO_USER_POOL_ID}"
+)
+
+
+@dataclass
+class WinixAuthResponse:
+    """Authentication data persisted by the integration."""
+
+    user_id: str
+    access_token: str
+    refresh_token: str
+    id_token: str
+    identity_id: str | None = None
+    expires_at: float | None = None
+
+    def __post_init__(self) -> None:
+        """Populate expiration when it is missing."""
+        if self.expires_at is None and self.access_token:
+            self.expires_at = _token_expiration(self.access_token)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Convert the dataclass into a JSON-serializable dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> WinixAuthResponse | None:
+        """Create an auth response from stored dict data."""
+        if not data:
+            return None
+        return cls(**data)
+
+
+def login(username: str, password: str) -> WinixAuthResponse:
+    """Authenticate against the current Winix Cognito user pool."""
+    client = _cognito_idp_client()
+    warrant = WarrantLite(
+        username=username,
+        password=password,
+        pool_id=COGNITO_USER_POOL_ID,
+        client_id=COGNITO_APP_CLIENT_ID,
+        client=client,
+    )
+    response = warrant.authenticate_user()
+    auth_result = response["AuthenticationResult"]
+    access_token = auth_result["AccessToken"]
+    return WinixAuthResponse(
+        user_id=jwt.get_unverified_claims(access_token)["sub"],
+        access_token=access_token,
+        refresh_token=auth_result["RefreshToken"],
+        id_token=auth_result["IdToken"],
+        expires_at=_expires_at(auth_result.get("ExpiresIn"), access_token),
+    )
+
+
+def refresh(user_id: str, refresh_token: str) -> WinixAuthResponse:
+    """Refresh an existing Winix session."""
+    response = _cognito_idp_client().initiate_auth(
+        ClientId=COGNITO_APP_CLIENT_ID,
+        AuthFlow="REFRESH_TOKEN",
+        AuthParameters={
+            "REFRESH_TOKEN": refresh_token,
+        },
+    )
+    auth_result = response["AuthenticationResult"]
+    access_token = auth_result["AccessToken"]
+    return WinixAuthResponse(
+        user_id=user_id,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        id_token=auth_result.get("IdToken", ""),
+        expires_at=_expires_at(auth_result.get("ExpiresIn"), access_token),
+    )
+
+
+def resolve_identity_id(id_token: str) -> str:
+    """Resolve the Cognito identity pool id needed by the Winix device API."""
+    response = _cognito_identity_client().get_id(
+        IdentityPoolId=IDENTITY_POOL_ID,
+        Logins={COGNITO_LOGINS_PROVIDER: id_token},
+    )
+    identity_id = response.get("IdentityId")
+    if not identity_id:
+        raise RuntimeError("Cognito GetId returned no IdentityId")
+    return identity_id
+
+
+def generate_uuid(access_token: str) -> str:
+    """Construct the fake Android secure id expected by Winix."""
+    if not access_token:
+        return ""
+
+    user_id_bytes = jwt.get_unverified_claims(access_token)["sub"].encode()
+    part1 = crc32(b"github.com/regaw-leinad/winix-api" + user_id_bytes)
+    part2 = crc32(b"HGF" + user_id_bytes)
+    return f"{part1:08x}{part2:08x}"
+
+
+def _cognito_idp_client():
+    """Return a Cognito IDP client without AWS credentials."""
+    return boto3.client(
+        "cognito-idp",
+        region_name=COGNITO_REGION,
+        config=Config(signature_version=UNSIGNED),
+    )
+
+
+def _cognito_identity_client():
+    """Return a Cognito Identity client without AWS credentials."""
+    return boto3.client(
+        "cognito-identity",
+        region_name=COGNITO_REGION,
+        config=Config(signature_version=UNSIGNED),
+    )
+
+
+def _expires_at(expires_in: int | None, access_token: str) -> float:
+    """Compute token expiration from the login response or JWT fallback."""
+    if expires_in is not None:
+        return (
+            datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
+        ).timestamp()
+    return _token_expiration(access_token)
+
+
+def _token_expiration(access_token: str) -> float:
+    """Read expiration from JWT claims and fall back to one hour."""
+    claims = jwt.get_unverified_claims(access_token)
+    exp = claims.get("exp")
+    if exp is not None:
+        return float(exp)
+    return (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()

--- a/custom_components/winix/config_flow.py
+++ b/custom_components/winix/config_flow.py
@@ -6,12 +6,12 @@ from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
-from winix import auth
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
 
+from .cloud import WinixAuthResponse
 from .const import LOGGER, WINIX_AUTH_RESPONSE, WINIX_DOMAIN, WINIX_NAME
 from .helpers import Helpers, WinixException
 
@@ -64,14 +64,12 @@ class WinixFlowHandler(config_entries.ConfigFlow, domain=WINIX_DOMAIN):
             )
             errors = errors_and_auth["errors"]
             if not errors:
-                auth_response: auth.WinixAuthResponse = errors_and_auth[
-                    WINIX_AUTH_RESPONSE
-                ]
+                auth_response: WinixAuthResponse = errors_and_auth[WINIX_AUTH_RESPONSE]
                 await self.async_set_unique_id(username)
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=WINIX_NAME,
-                    data={**user_input, WINIX_AUTH_RESPONSE: auth_response},
+                    data={**user_input, WINIX_AUTH_RESPONSE: auth_response.as_dict()},
                 )
 
         return self.async_show_form(
@@ -96,13 +94,13 @@ class WinixFlowHandler(config_entries.ConfigFlow, domain=WINIX_DOMAIN):
             errors_and_auth = await self._validate_input(username, password)
             errors = errors_and_auth["errors"]
             if not errors:
-                auth_response = errors_and_auth[WINIX_AUTH_RESPONSE]
+                auth_response: WinixAuthResponse = errors_and_auth[WINIX_AUTH_RESPONSE]
                 self.hass.config_entries.async_update_entry(
                     existing_entry,
                     data={
                         **existing_entry.data,
                         CONF_PASSWORD: password,
-                        WINIX_AUTH_RESPONSE: auth_response,
+                        WINIX_AUTH_RESPONSE: auth_response.as_dict(),
                     },
                 )
                 await self.hass.config_entries.async_reload(existing_entry.entry_id)

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -52,12 +52,12 @@ class WinixDeviceWrapper:
         client: aiohttp.ClientSession,
         device_stub: MyWinixDeviceStub,
         filter_alarm_duration_hours: int,
+        identity_id: str | None,
         logger,
-        identity_id: str,
     ) -> None:
         """Initialize the wrapper."""
 
-        self._driver = WinixDriver(device_stub.id, client, identity_id)
+        self._driver = WinixDriver(device_stub.id, identity_id, client)
 
         # Start as empty object in case fan was operated before it got updated
         self._state = {}

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -66,12 +66,12 @@ class WinixDriver:
     }
 
     def __init__(
-        self, device_id: str, client: aiohttp.ClientSession, identity_id: str
+        self, device_id: str, identity_id: str | None, client: aiohttp.ClientSession
     ) -> None:
         """Create an instance of WinixDevice."""
         self.device_id = device_id
+        self.identity_id = identity_id
         self._client = client
-        self._identity_id = identity_id
 
     async def turn_off(self) -> None:
         """Turn the device off."""
@@ -158,11 +158,16 @@ class WinixDriver:
     async def _rpc_attr(self, attr: str, value: str) -> None:
         LOGGER.debug("_rpc_attr attribute=%s, value=%s", attr, value)
 
+        if not self.identity_id:
+            raise HomeAssistantError(
+                "Missing Winix identity_id. Reconfigure the integration."
+            )
+
         try:
             response = await self._client.get(
                 self.CTRL_URL.format(
                     deviceid=self.device_id,
-                    identityid=self._identity_id,
+                    identityid=self.identity_id,
                     attribute=attr,
                     value=value,
                 )

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -3,22 +3,28 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import datetime, timedelta
 from http import HTTPStatus
 import json
 from typing import Any
 
 import aiohttp
-import boto3
-from botocore import UNSIGNED
-from botocore.client import Config
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad, unpad
 import requests
-from winix import WinixAccount, auth
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
+from .cloud import (
+    MOBILE_APP_VERSION,
+    MOBILE_MODEL,
+    WinixAuthResponse,
+    generate_uuid,
+    login as cloud_login,
+    refresh as cloud_refresh,
+    resolve_identity_id,
+)
 from .const import (
     DEFAULT_FILTER_ALARM_DURATION,
     DEFAULT_POST_TIMEOUT,
@@ -26,24 +32,6 @@ from .const import (
     WINIX_DOMAIN,
 )
 from .device_wrapper import MyWinixDeviceStub
-
-# Winix rotated their Cognito app client on 2026-04-16. The old client ID
-# (14og512b9u20b8vrdm55d8empi) is dead. Patch the pip package constants before
-# any auth calls are made. The new client has no client secret.
-auth.COGNITO_APP_CLIENT_ID = "5rjk59c5tt7k9g8gpj0vd2qfg9"
-auth.COGNITO_CLIENT_SECRET_KEY = None
-
-_COGNITO_IDENTITY_POOL_ID = "us-east-1:84008e15-d6af-4698-8646-66d05c1abe8b"
-_COGNITO_USER_POOL_ID = "us-east-1_Ofd50EosD"
-
-# Both Cognito services are public endpoints — no AWS credentials required.
-_UNSIGNED_CONFIG = Config(signature_version=UNSIGNED)
-_COGNITO_IDP_CLIENT = boto3.client(
-    "cognito-idp", config=_UNSIGNED_CONFIG, region_name="us-east-1"
-)
-_COGNITO_IDENTITY_CLIENT = boto3.client(
-    "cognito-identity", config=_UNSIGNED_CONFIG, region_name="us-east-1"
-)
 
 HEADERS = {
     "Content-Type": "application/octet-stream",
@@ -65,8 +53,8 @@ class Helpers:
         "osType": "android",
         "osVersion": "29",
         "mobileLang": "en",
-        "appVersion": "1.5.7",
-        "mobileModel": "SM-G988B",
+        "appVersion": MOBILE_APP_VERSION,
+        "mobileModel": MOBILE_MODEL,
     }
 
     @staticmethod
@@ -118,86 +106,84 @@ class Helpers:
     @staticmethod
     async def async_login(
         hass: HomeAssistant, username: str, password: str
-    ) -> auth.WinixAuthResponse:
+    ) -> WinixAuthResponse:
         """Log in asynchronously."""
 
         return await hass.async_add_executor_job(Helpers.login, username, password)
 
     @staticmethod
-    def login(username: str, password: str) -> auth.WinixAuthResponse:
+    def login(username: str, password: str) -> WinixAuthResponse:
         """Log in synchronously."""
 
         try:
-            response = auth.login(username, password)
+            response = cloud_login(username, password)
         except Exception as err:  # pylint: disable=broad-except
             raise WinixException.from_aws_exception(err) from err
 
         access_token = response.access_token
-        uuid = WinixAccount(access_token).get_uuid()
-        identity_id = Helpers.get_identity_id_sync(response.id_token)
+        uuid = generate_uuid(access_token)
 
         try:
-            # v1.5.7 session establishment order:
-            # registerUser (needs identityId) → init → checkAccessToken (needs identityId)
-            Helpers._register_user(access_token, uuid, username, identity_id)
-            Helpers._init(access_token, uuid)
-            Helpers._check_access_token(access_token, uuid, identity_id)
+            response.identity_id = resolve_identity_id(response.id_token)
+            Helpers._register_user(
+                access_token, uuid, username, response.identity_id
+            )
+            Helpers._init_session(access_token, uuid)
+            Helpers._check_access_token(access_token, uuid, response.identity_id)
         except Exception as err:  # pylint: disable=broad-except
             raise WinixException.from_winix_exception(err) from err
 
+        expires_at = response.expires_at or (
+            datetime.now() + timedelta(seconds=3600)
+        ).timestamp()
+        LOGGER.debug("Login successful, token expires %.0f", expires_at)
         return response
 
     @staticmethod
     async def async_refresh_auth(
-        hass: HomeAssistant, response: auth.WinixAuthResponse
-    ) -> auth.WinixAuthResponse:
+        hass: HomeAssistant, username: str, response: WinixAuthResponse
+    ) -> WinixAuthResponse:
         """Refresh authentication.
 
         Raises WinixException.
         """
 
-        def _refresh(response: auth.WinixAuthResponse) -> auth.WinixAuthResponse:
+        def _refresh(username: str, response: WinixAuthResponse) -> WinixAuthResponse:
             LOGGER.debug("Attempting re-authentication")
 
-            # Use boto3 directly — auth.refresh() calls WarrantLite.get_secret_hash()
-            # which breaks with client_secret=None (new public client has no secret).
-            # New public client has no secret — no SECRET_HASH in refresh params.
             try:
-                resp = _COGNITO_IDP_CLIENT.initiate_auth(
-                    ClientId=auth.COGNITO_APP_CLIENT_ID,
-                    AuthFlow="REFRESH_TOKEN",
-                    AuthParameters={"REFRESH_TOKEN": response.refresh_token},
+                refreshed_response = cloud_refresh(
+                    user_id=response.user_id, refresh_token=response.refresh_token
                 )
             except Exception as err:  # pylint: disable=broad-except
                 raise WinixException.from_aws_exception(err) from err
 
-            result = resp["AuthenticationResult"]
-            new_response = auth.WinixAuthResponse(
-                user_id=response.user_id,
-                access_token=result["AccessToken"],
-                refresh_token=response.refresh_token,
-                id_token=result["IdToken"],
-            )
-
-            uuid = WinixAccount(new_response.access_token).get_uuid()
-            identity_id = Helpers.get_identity_id_sync(new_response.id_token)
-            LOGGER.debug("Re-establishing session after token refresh")
+            uuid = generate_uuid(refreshed_response.access_token)
+            LOGGER.debug("Attempting session re-establishment")
 
             try:
-                Helpers._register_user(
-                    new_response.access_token, uuid, response.user_id, identity_id
+                refreshed_response.identity_id = resolve_identity_id(
+                    refreshed_response.id_token
                 )
-                Helpers._init(new_response.access_token, uuid)
+                Helpers._register_user(
+                    refreshed_response.access_token,
+                    uuid,
+                    username,
+                    refreshed_response.identity_id,
+                )
+                Helpers._init_session(refreshed_response.access_token, uuid)
                 Helpers._check_access_token(
-                    new_response.access_token, uuid, identity_id
+                    refreshed_response.access_token,
+                    uuid,
+                    refreshed_response.identity_id,
                 )
             except Exception as err:  # pylint: disable=broad-except
                 raise WinixException.from_winix_exception(err) from err
 
             LOGGER.debug("Re-authentication successful")
-            return new_response
+            return refreshed_response
 
-        return await hass.async_add_executor_job(_refresh, response)
+        return await hass.async_add_executor_job(_refresh, username, response)
 
     @staticmethod
     def _build_mobile_app_payload(
@@ -211,103 +197,6 @@ class Helpers:
             **Helpers._MOBILE_APP_METADATA,
             **kwargs,
         }
-
-    @staticmethod
-    def get_identity_id_sync(id_token: str) -> str:
-        """Get the Cognito Identity ID synchronously (for use in executor threads).
-
-        The CTRL_URL requires the user's identityId from the Cognito Identity Pool
-        instead of the old hardcoded 'A211' path segment. Uses boto3 so the AWS
-        JSON protocol headers are handled correctly.
-
-        Raises WinixException.
-        """
-        login_key = f"cognito-idp.us-east-1.amazonaws.com/{_COGNITO_USER_POOL_ID}"
-
-        try:
-            response = _COGNITO_IDENTITY_CLIENT.get_id(
-                IdentityPoolId=_COGNITO_IDENTITY_POOL_ID,
-                Logins={login_key: id_token},
-            )
-        except Exception as err:  # pylint: disable=broad-except
-            # Map NotAuthorizedException (expired id_token) to result_code so
-            # callers can trigger re-auth rather than failing permanently.
-            code = (
-                "NotAuthorizedException" if "NotAuthorizedException" in str(err) else ""
-            )
-            raise WinixException(
-                {
-                    "message": f"Failed to get Cognito Identity ID: {err}",
-                    "result_code": code,
-                }
-            ) from err
-
-        identity_id = response.get("IdentityId")
-        if not identity_id:
-            raise WinixException(
-                {"message": "Cognito Identity ID missing from response."}
-            )
-
-        LOGGER.debug("Got Cognito identityId: %s", identity_id)
-        return identity_id
-
-    @staticmethod
-    def _init(access_token: str, uuid: str) -> None:
-        """Call the Winix /init endpoint. Required as of v1.5.7 between registerUser and checkAccessToken.
-
-        Raises WinixException.
-        """
-
-        resp = requests.post(
-            "https://us.mobile.winix-iot.com/init",
-            headers=HEADERS,
-            data=Helpers.encrypt(
-                {
-                    "accessToken": access_token,
-                    "uuid": uuid,
-                    "region": "US",
-                }
-            ),
-            timeout=DEFAULT_POST_TIMEOUT,
-        )
-
-        binary_data = resp.content
-        response_json_text = Helpers.decrypt(binary_data)
-        response_json = Helpers.json_loads(response_json_text)
-
-        if resp.status_code != HTTPStatus.OK:
-            response_json["message"] = (
-                f"Error while performing RPC init ({resp.status_code})"
-            )
-            raise WinixException(response_json)
-
-    @staticmethod
-    def _check_access_token(access_token: str, uuid: str, identity_id: str) -> None:
-        """Validate the access token with Winix cloud using current app metadata.
-
-        Raises WinixException.
-        """
-
-        resp = requests.post(
-            "https://us.mobile.winix-iot.com/checkAccessToken",
-            headers=HEADERS,
-            data=Helpers.encrypt(
-                Helpers._build_mobile_app_payload(
-                    access_token, uuid, identityId=identity_id
-                )
-            ),
-            timeout=DEFAULT_POST_TIMEOUT,
-        )
-
-        binary_data = resp.content
-        response_json_text = Helpers.decrypt(binary_data)
-        response_json = Helpers.json_loads(response_json_text)
-
-        if resp.status_code != HTTPStatus.OK:
-            response_json["message"] = (
-                f"Error while performing RPC checkAccessToken ({resp.status_code})"
-            )
-            raise WinixException(response_json)
 
     @staticmethod
     def _register_user(
@@ -332,12 +221,69 @@ class Helpers:
         binary_data = resp.content
         response_json_text = Helpers.decrypt(binary_data)
         response_json = Helpers.json_loads(response_json_text)
+        Helpers._ensure_mobile_success("registerUser", resp.status_code, response_json)
 
-        if resp.status_code != HTTPStatus.OK:
-            response_json["message"] = (
-                f"Error while performing RPC registerUser ({resp.status_code})"
-            )
-            raise WinixException(response_json)
+    @staticmethod
+    def _init_session(access_token: str, uuid: str) -> None:
+        """Initialize the Winix mobile session for the new cloud flow."""
+
+        resp = requests.post(
+            "https://us.mobile.winix-iot.com/init",
+            headers=HEADERS,
+            data=Helpers.encrypt(
+                Helpers._build_mobile_app_payload(access_token, uuid, region="US")
+            ),
+            timeout=DEFAULT_POST_TIMEOUT,
+        )
+
+        binary_data = resp.content
+        response_json_text = Helpers.decrypt(binary_data)
+        response_json = Helpers.json_loads(response_json_text)
+        Helpers._ensure_mobile_success("init", resp.status_code, response_json)
+
+    @staticmethod
+    def _check_access_token(access_token: str, uuid: str, identity_id: str) -> None:
+        """Validate the access token with Winix cloud using current app metadata.
+
+        Raises WinixException.
+        """
+
+        resp = requests.post(
+            "https://us.mobile.winix-iot.com/checkAccessToken",
+            headers=HEADERS,
+            data=Helpers.encrypt(
+                Helpers._build_mobile_app_payload(
+                    access_token, uuid, identityId=identity_id
+                )
+            ),
+            timeout=DEFAULT_POST_TIMEOUT,
+        )
+
+        binary_data = resp.content
+        response_json_text = Helpers.decrypt(binary_data)
+        response_json = Helpers.json_loads(response_json_text)
+        Helpers._ensure_mobile_success(
+            "checkAccessToken", resp.status_code, response_json
+        )
+
+    @staticmethod
+    def _ensure_mobile_success(
+        operation: str, status_code: int, response_json: dict[str, Any]
+    ) -> None:
+        """Validate the decrypted mobile API response."""
+
+        result_code = str(response_json.get("resultCode", ""))
+        result_message = response_json.get("resultMessage", "")
+
+        if status_code == HTTPStatus.OK and (not result_code or result_code == "200"):
+            return
+
+        response_json["message"] = (
+            f"Error while performing RPC {operation} ({status_code})"
+        )
+        response_json["result_code"] = result_code
+        response_json["result_message"] = result_message
+        raise WinixException(response_json)
 
     @staticmethod
     async def get_filter_alarm_duration(
@@ -368,16 +314,10 @@ class Helpers:
                 }
             )
 
-        response_json = (
-            await resp.json()
-        )  # Note: filterAlarmInfo returns unencrypted JSON
+        response_json = await resp.json()
 
-        # Sample json
-        # {'resultCode': '200', 'resultMessage': 'SUCCESS', 'filterUsageAlarm': 9}
-        LOGGER.debug("getFilterAlarmInfo: %s", response_json)
+        LOGGER.debug(f"getFilterAlarmInfo: {response_json}")
 
-        # Fall back to 9 months if filter alram has been turned off in mobile app in which case we receive this:
-        # {'resultCode': '200', 'resultMessage': 'SUCCESS', 'filterUsageAlarm': 0}
         value = int(response_json["filterUsageAlarm"])
 
         if value == 0:
@@ -393,15 +333,6 @@ class Helpers:
         Raises WinixException.
         """
 
-        # Modified from https://github.com/hfern/winix to support additional attributes.
-
-        # com.google.gson.k kVar = new com.google.gson.k();
-        # kVar.p("accessToken", deviceMainActivity2.f2938o);
-        # kVar.p("uuid", Common.w(deviceMainActivity2.f2934k));
-        # new com.winix.smartiot.util.o0(deviceMainActivity2.f2934k, "https://us.mobile.winix-iot.com/getDeviceInfoList", kVar).a(new TypeToken<g4.v>() {
-        #  // from class: com.winix.smartiot.activity.DeviceMainActivity.9
-        # }, new com.winix.smartiot.activity.d(deviceMainActivity2, 4));
-
         resp = await client.post(
             "https://us.mobile.winix-iot.com/getDeviceInfoList",
             headers=HEADERS,
@@ -414,19 +345,13 @@ class Helpers:
             timeout=DEFAULT_POST_TIMEOUT,
         )
 
-        binary_data = await resp.read()
+        binary_data = resp.content
+        response_json_text = Helpers.decrypt(await binary_data.read())
+        response_json = Helpers.json_loads(response_json_text)
 
-        if resp.status != HTTPStatus.OK:
-            # Safely decrypt binary_data, generic errors might not be encrypted
-            try:
-                err_text = Helpers.decrypt(binary_data)
-                err_data = Helpers.json_loads(err_text)
-            except Exception:  # noqa: BLE001
-                err_data = {}
-
-            result_code = err_data.get("resultCode")
-            result_message = err_data.get("resultMessage")
-
+        result_code = str(response_json.get("resultCode", "200"))
+        result_message = response_json.get("resultMessage", "")
+        if resp.status != HTTPStatus.OK or result_code != "200":
             raise WinixException(
                 {
                     "message": f"Failed to get device list (code-{result_code}). {result_message}.",
@@ -434,9 +359,6 @@ class Helpers:
                     "result_message": result_message,
                 }
             )
-
-        response_json_text = Helpers.decrypt(binary_data)
-        response_json = Helpers.json_loads(response_json_text)
 
         return [
             MyWinixDeviceStub(
@@ -453,7 +375,7 @@ class Helpers:
 
 
 class WinixException(HomeAssistantError):
-    """Winix related operation exception."""
+    """Wiinx related operation exception."""
 
     result_code: str = ""
     """Error code."""
@@ -504,7 +426,6 @@ class WinixException(HomeAssistantError):
         """Parse AWS operation exception."""
         message = str(err)
 
-        # https://stackoverflow.com/questions/60703127/how-to-catch-botocore-errorfactory-usernotfoundexception
         try:
             response = err.response
             if response:

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from winix import WinixAccount, auth
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -14,6 +12,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
+from .cloud import WinixAuthResponse, generate_uuid
 from .const import LOGGER, WINIX_DOMAIN
 from .device_wrapper import WinixDeviceWrapper
 from .helpers import Helpers
@@ -56,14 +55,12 @@ class WinixManager(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         entry: ConfigEntry,
-        auth_response: auth.WinixAuthResponse,
+        auth_response: WinixAuthResponse,
         scan_interval: int,
         client,
     ) -> None:
         """Initialize the manager."""
 
-        # Always initialize _device_wrappers in case async_prepare_devices_wrappers
-        # was not invoked.
         self._device_wrappers: list[WinixDeviceWrapper] = []
         self._auth_response = auth_response
         self._client = client
@@ -78,10 +75,7 @@ class WinixManager(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> None:
         """Fetch the latest data from the source. This overrides the method in DataUpdateCoordinator."""
-
-        LOGGER.info("Updating devices")
-        for device_wrapper in self._device_wrappers:
-            await device_wrapper.update()
+        await self.async_update()
 
     def update_features(self) -> None:
         """Update the supported features based on the current state."""
@@ -89,32 +83,18 @@ class WinixManager(DataUpdateCoordinator):
             wrapper.update_features()
 
     async def prepare_devices_wrappers(
-        self, access_token: str = "", id_token: str = ""
+        self, access_token: str = "", identity_id: str | None = None
     ) -> None:
         """Prepare device wrappers.
 
         Raises WinixException.
         """
-        self._device_wrappers = []  # Reset device_stubs
+        self._device_wrappers = []
 
         token = access_token or self._auth_response.access_token
-        id_tok = id_token or self._auth_response.id_token
-        uuid = WinixAccount(token).get_uuid()
-
-        try:
-            device_stubs = await Helpers.get_device_stubs(self._client, token, uuid)
-        except Exception as err:
-            LOGGER.error("Failed to get device stubs: %s", err, exc_info=True)
-            raise
-
-        # boto3 call must run in an executor thread (synchronous I/O).
-        try:
-            identity_id = await self.hass.async_add_executor_job(
-                Helpers.get_identity_id_sync, id_tok
-            )
-        except Exception as err:
-            LOGGER.error("Failed to get identity_id: %s", err, exc_info=True)
-            raise
+        resolved_identity_id = identity_id or self._auth_response.identity_id
+        uuid = generate_uuid(token)
+        device_stubs = await Helpers.get_device_stubs(self._client, token, uuid)
 
         if device_stubs:
             for device_stub in device_stubs:
@@ -126,14 +106,20 @@ class WinixManager(DataUpdateCoordinator):
                         self._client,
                         device_stub,
                         filter_alarm_duration,
+                        resolved_identity_id,
                         LOGGER,
-                        identity_id,
                     )
                 )
 
             LOGGER.info("%d purifiers found", len(self._device_wrappers))
         else:
             LOGGER.info("No purifiers found")
+
+    async def async_update(self, now=None) -> None:
+        """Asynchronously update all the devices."""
+        LOGGER.info("Updating devices")
+        for device_wrapper in self._device_wrappers:
+            await device_wrapper.update()
 
     def get_device_wrappers(self) -> list[WinixDeviceWrapper]:
         """Return the device wrapper objects."""


### PR DESCRIPTION
This follows up on the 1.3.9 Winix cloud auth fix.

The current version works functionally, but this patch makes auth/session handling more robust for Home Assistant by persisting the full auth state and reducing reliance on the legacy `winix==0.3.0` auth internals.

Changes:
- add a dedicated `cloud.py` module for Winix Cognito login/refresh/identity handling
- persist `WINIX_AUTH_RESPONSE` as a serializable dict instead of a live `auth.WinixAuthResponse` object
- store and reuse `identity_id` and `expires_at`
- auto-migrate older config entries that do not yet have `identity_id`
- pass stored `identity_id` through manager/device/control flow instead of recomputing it every time
- validate decrypted mobile API responses by `resultCode` / `resultMessage`, not only HTTP status
Why:
- improves reload/restart persistence
- makes auth state handling clearer and easier to maintain
- reduces risk of control failures caused by missing or stale `identity_id`
- surfaces Winix cloud-side failures more reliably

I tested these changes on my own Home Assistant instance running HA Core `2026.2.3`, and everything looks correct from my side.
It would also be great if others in the community could review and test this approach for errors and overall usefulness before merging.
This is intended as a small hardening follow-up on top of the 1.3.9 auth fix, not a behavioral change for users with already-working setups.