### PR TITLE
feat: wire product_group from API response through to driver selection

### DIFF
--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -28,12 +28,12 @@ from .const import (
     Features,
     NumericPresetModes,
 )
-from .driver import AirPurifierDriver
+from .driver import AirPurifierDriver, WinixDriver
 
 
 @dataclasses.dataclass
 class MyWinixDeviceStub:
-    """Winix purifier device information."""
+    """Winix device information."""
 
     id: str
     mac: str
@@ -42,6 +42,23 @@ class MyWinixDeviceStub:
     filter_replace_date: str
     model: str
     sw_version: str
+    product_group: str
+
+
+def _select_driver(
+    device_stub: MyWinixDeviceStub,
+    client: aiohttp.ClientSession,
+    identity_id: str,
+) -> WinixDriver:
+    """Return the driver that matches the device's product group."""
+
+    product_group = (device_stub.product_group or "").casefold()
+    if product_group.startswith("air"):
+        return AirPurifierDriver(device_stub.id, client, identity_id)
+
+    raise ValueError(
+        f"Unsupported product_group '{device_stub.product_group}' for device {device_stub.alias}"
+    )
 
 
 class WinixDeviceWrapper:
@@ -59,7 +76,7 @@ class WinixDeviceWrapper:
     ) -> None:
         """Initialize the wrapper."""
 
-        self._driver = AirPurifierDriver(device_stub.id, client, identity_id)
+        self._driver = _select_driver(device_stub, client, identity_id)
 
         # Start as empty object in case fan was operated before it got updated
         self._state = {}

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -447,6 +447,7 @@ class Helpers:
                 filter_replace_date=item.get("filterReplaceDate"),
                 model=item.get("modelName"),
                 sw_version=item.get("mcuVer"),
+                product_group=item.get("productGroup"),
             )
             for item in response_json["deviceInfoList"]
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ async def device_stub() -> MyWinixDeviceStub:
         filter_replace_date="filterReplaceDate",
         model="modelName",
         sw_version="mcuVer",
+        product_group="Air01",
     )
 
 
@@ -86,7 +87,7 @@ def mock_device_wrapper() -> WinixDeviceWrapper:
 
 
 @pytest.fixture
-def mock_driver() -> AirPurifierDriver:
+def mock_airpurifier_driver() -> AirPurifierDriver:
     """Return a mocked AirPurifierDriver instance."""
     client = Mock()
     device_id = "device_1"
@@ -95,7 +96,7 @@ def mock_driver() -> AirPurifierDriver:
 
 
 @pytest.fixture
-def mock_driver_with_payload(request: pytest.FixtureRequest) -> AirPurifierDriver:
+def mock_airpurifier_driver_with_payload(request: pytest.FixtureRequest) -> AirPurifierDriver:
     """Return a mocked AirPurifierDriver instance."""
 
     json_value = {"body": {"data": [{"attributes": request.param}]}}

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -24,10 +24,10 @@ from custom_components.winix.driver import AirPurifierDriver
         ("sleep", "airflow", "sleep"),
     ],
 )
-async def test_turn_off(mock_rpc_attr, mock_driver, method, category, value) -> None:
+async def test_turn_off(mock_rpc_attr, mock_airpurifier_driver, method, category, value) -> None:
     """Test various driver methods."""
 
-    await getattr(mock_driver, method)()
+    await getattr(mock_airpurifier_driver, method)()
     assert mock_rpc_attr.call_count == 1
     assert mock_rpc_attr.call_args[0] == (
         AirPurifierDriver.category_keys[category],
@@ -36,19 +36,19 @@ async def test_turn_off(mock_rpc_attr, mock_driver, method, category, value) -> 
 
 
 @pytest.mark.parametrize(
-    ("mock_driver_with_payload", "expected"),
+    ("mock_airpurifier_driver_with_payload", "expected"),
     [
         ({"A02": "0"}, {"power": "off"}),
         ({"A02": "1"}, {"power": "on"}),
         ({"S08": "79"}, {"air_qvalue": 79}),  # air_qvalue
         ({"S04": "12"}, {"pm2_5": 12}),  # pm2_5
     ],
-    indirect=["mock_driver_with_payload"],
+    indirect=["mock_airpurifier_driver_with_payload"],
 )
-async def test_get_state(mock_driver_with_payload, expected) -> None:
+async def test_get_state(mock_airpurifier_driver_with_payload, expected) -> None:
     """Test get_state for AirPurifierDriver."""
 
     # payload = {"A02": "0"}  # "A02" represents "power" and "0" means "off"
 
-    state = await mock_driver_with_payload.get_state()
+    state = await mock_airpurifier_driver_with_payload.get_state()
     assert state == expected


### PR DESCRIPTION
Related Issue, PR: #151, #154

This is the second PR split out from PR #154. The original plan was to introduce the deviceInfoList.productGroup value along with the Driver and DeviceWrapper implementations for the dehumidifier.

However, more time is needed to further clean up the code during the rebase and split process. So for now, only the functionality that consumes the productGroup value is being submitted as this  PR.

All unit tests pass.