### PR TITLE
add DehumidifierDriver

### DIFF
--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -28,6 +28,11 @@ ATTR_LAST_BRIGHTNESS_LEVEL: Final = "last_brightness_level"
 ATTR_BRIGHTNESS_LEVEL: Final = "brightness_level"
 ATTR_CHILD_LOCK: Final = "child_lock"
 ATTR_AMBIENT_LIGHT: Final = "ambient_light"
+ATTR_TARGET_HUMIDITY: Final = "target_humidity"
+ATTR_CURRENT_HUMIDITY: Final = "current_humidity"
+ATTR_WATER_TANK: Final = "water_tank"
+ATTR_UV_SANITIZE: Final = "uv_sanitize"
+ATTR_TIMER: Final = "timer"
 
 SENSOR_AIR_QVALUE: Final = "air_qvalue"
 SENSOR_PM25: Final = "pm2_5"
@@ -36,6 +41,7 @@ SENSOR_FILTER_LIFE: Final = "filter_life"
 
 OFF_VALUE: Final = "off"
 ON_VALUE: Final = "on"
+AUTO_DRY_VALUE: Final = "auto-dry"
 
 AIR_QUALITY_GOOD: Final = "good"
 AIR_QUALITY_FAIR: Final = "fair"
@@ -74,6 +80,10 @@ DEFAULT_POST_TIMEOUT: Final = 5
 # mode can contain the special preset value of manual.
 MODE_AUTO: Final = "auto"
 MODE_MANUAL: Final = "manual"
+MODE_CLOTHES: Final = "clothes"
+MODE_SHOES: Final = "shoes"
+MODE_QUIET: Final = "quiet"
+MODE_CONTINUOUS: Final = "continuous"
 
 PRESET_MODE_AUTO: Final = "Auto"
 PRESET_MODE_AUTO_PLASMA_OFF: Final = "Auto (PlasmaWave off)"

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -24,14 +24,24 @@ from .const import (
     ATTR_AMBIENT_LIGHT,
     ATTR_BRIGHTNESS_LEVEL,
     ATTR_CHILD_LOCK,
+    ATTR_CURRENT_HUMIDITY,
     ATTR_FILTER_HOUR,
     ATTR_MODE,
     ATTR_PLASMA,
     ATTR_PM25,
     ATTR_POWER,
+    ATTR_TARGET_HUMIDITY,
+    ATTR_TIMER,
+    ATTR_UV_SANITIZE,
+    ATTR_WATER_TANK,
+    AUTO_DRY_VALUE,
     LOGGER,
     MODE_AUTO,
+    MODE_CLOTHES,
+    MODE_CONTINUOUS,
     MODE_MANUAL,
+    MODE_QUIET,
+    MODE_SHOES,
     OFF_VALUE,
     ON_VALUE,
 )
@@ -324,3 +334,92 @@ class AirPurifierDriver(WinixDriver):
                 return int(attributes["P01"])
         except Exception:  # pylint: disable=broad-except # noqa: BLE001
             return None
+
+
+class DehumidifierDriver(WinixDriver):
+    """Winix Dehumidifier driver."""
+
+    category_keys = {
+        ATTR_POWER: "D02",
+        ATTR_MODE: "D03",
+        ATTR_AIRFLOW: "D04",
+        ATTR_TARGET_HUMIDITY: "D05",
+        ATTR_CHILD_LOCK: "D08",
+        ATTR_CURRENT_HUMIDITY: "D10",
+        ATTR_WATER_TANK: "D11",
+        ATTR_UV_SANITIZE: "D13",
+        ATTR_TIMER: "D15",
+    }
+
+    state_keys = {
+        ATTR_POWER: {
+            OFF_VALUE: "0",
+            ON_VALUE: "1",
+            AUTO_DRY_VALUE: "2",
+        },
+        ATTR_MODE: {
+            MODE_AUTO: "01",
+            MODE_MANUAL: "02",
+            MODE_CLOTHES: "03",
+            MODE_SHOES: "04",
+            MODE_QUIET: "05",
+            MODE_CONTINUOUS: "06",
+        },
+        ATTR_AIRFLOW: {
+            AIRFLOW_HIGH: "01",
+            AIRFLOW_LOW: "02",
+            AIRFLOW_TURBO: "03",
+        },
+        ATTR_CHILD_LOCK: {
+            OFF_VALUE: "0",
+            ON_VALUE: "1",
+        },
+        ATTR_WATER_TANK: {
+            OFF_VALUE: "0",  # not full and tank attached
+            ON_VALUE: "1",  # full or tank detached
+        },
+        ATTR_UV_SANITIZE: {
+            OFF_VALUE: "0",
+            ON_VALUE: "1",
+        },
+    }
+
+    async def turn_on(self) -> None:
+        """Turn the device on."""
+        await self.control(ATTR_POWER, ON_VALUE)
+
+    async def turn_off(self) -> None:
+        """Turn the device off."""
+        await self.control(ATTR_POWER, OFF_VALUE)
+
+    async def set_mode(self, mode: str) -> None:
+        """Set operating mode."""
+        await self.control(ATTR_MODE, mode)
+
+    async def set_fan_speed(self, speed: str) -> None:
+        """Set fan speed."""
+        await self.control(ATTR_AIRFLOW, speed)
+
+    async def set_humidity(self, humidity: int) -> None:
+        """Set target humidity."""
+        await self._rpc_attr(self.category_keys[ATTR_TARGET_HUMIDITY], str(humidity))
+
+    async def child_lock_off(self) -> None:
+        """Turn child lock off."""
+        await self.control(ATTR_CHILD_LOCK, OFF_VALUE)
+
+    async def child_lock_on(self) -> None:
+        """Turn child lock on."""
+        await self.control(ATTR_CHILD_LOCK, ON_VALUE)
+
+    async def uv_sanitize_off(self) -> None:
+        """Turn UV sanitize off."""
+        await self.control(ATTR_UV_SANITIZE, OFF_VALUE)
+
+    async def uv_sanitize_on(self) -> None:
+        """Turn UV sanitize on."""
+        await self.control(ATTR_UV_SANITIZE, ON_VALUE)
+
+    async def set_timer(self, hours: int) -> None:
+        """Set timer in hours (0 to disable)."""
+        await self._rpc_attr(self.category_keys[ATTR_TIMER], str(hours))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 
 from custom_components.winix.device_wrapper import MyWinixDeviceStub, WinixDeviceWrapper
-from custom_components.winix.driver import AirPurifierDriver
+from custom_components.winix.driver import AirPurifierDriver, DehumidifierDriver
 
 from .common import TEST_DEVICE_ID  # noqa: TID251
 
@@ -111,3 +111,30 @@ def mock_airpurifier_driver_with_payload(request: pytest.FixtureRequest) -> AirP
     device_id = "device_1"
     identity_id = "test_identity_id"
     return AirPurifierDriver(device_id, client, identity_id)
+
+
+@pytest.fixture
+def mock_dehumidifier_driver() -> DehumidifierDriver:
+    """Return a mocked DehumidifierDriver instance."""
+    client = Mock()
+    device_id = "device_1"
+    identity_id = "test_identity_id"
+    return DehumidifierDriver(device_id, client, identity_id)
+
+
+@pytest.fixture
+def mock_dehumidifier_driver_with_payload(request: pytest.FixtureRequest) -> DehumidifierDriver:
+    """Return a mocked DehumidifierDriver instance with preset payload."""
+
+    json_value = {"body": {"data": [{"attributes": request.param}]}}
+
+    response = Mock()
+    response.json = AsyncMock(return_value=json_value)
+    response.status = 200
+
+    client = Mock()  # aiohttp.ClientSession
+    client.get = AsyncMock(return_value=response)
+
+    device_id = "device_1"
+    identity_id = "test_identity_id"
+    return DehumidifierDriver(device_id, client, identity_id)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
-from custom_components.winix.driver import AirPurifierDriver
+from custom_components.winix.driver import AirPurifierDriver, DehumidifierDriver
+
+
+# ---------------------------------------------------------------------------
+# AirPurifierDriver tests
+# ---------------------------------------------------------------------------
 
 
 @patch("custom_components.winix.driver.WinixDriver._rpc_attr")
@@ -51,4 +56,86 @@ async def test_get_state(mock_airpurifier_driver_with_payload, expected) -> None
     # payload = {"A02": "0"}  # "A02" represents "power" and "0" means "off"
 
     state = await mock_airpurifier_driver_with_payload.get_state()
+    assert state == expected
+
+
+# ---------------------------------------------------------------------------
+# DehumidifierDriver tests
+# ---------------------------------------------------------------------------
+
+
+@patch("custom_components.winix.driver.WinixDriver._rpc_attr")
+@pytest.mark.parametrize(
+    ("method", "args", "category", "value"),
+    [
+        ("turn_on", [], "power", "on"),
+        ("turn_off", [], "power", "off"),
+        ("set_mode", ["auto"], "mode", "auto"),
+        ("set_mode", ["manual"], "mode", "manual"),
+        ("set_mode", ["clothes"], "mode", "clothes"),
+        ("set_mode", ["shoes"], "mode", "shoes"),
+        ("set_mode", ["quiet"], "mode", "quiet"),
+        ("set_mode", ["continuous"], "mode", "continuous"),
+        ("set_fan_speed", ["high"], "airflow", "high"),
+        ("set_fan_speed", ["low"], "airflow", "low"),
+        ("set_fan_speed", ["turbo"], "airflow", "turbo"),
+        ("child_lock_on", [], "child_lock", "on"),
+        ("child_lock_off", [], "child_lock", "off"),
+        ("uv_sanitize_on", [], "uv_sanitize", "on"),
+        ("uv_sanitize_off", [], "uv_sanitize", "off"),
+    ],
+)
+async def test_dehumidifier_control(
+    mock_rpc_attr, mock_dehumidifier_driver, method, args, category, value
+) -> None:
+    """Test DehumidifierDriver control methods."""
+
+    await getattr(mock_dehumidifier_driver, method)(*args)
+    assert mock_rpc_attr.call_count == 1
+    assert mock_rpc_attr.call_args[0] == (
+        DehumidifierDriver.category_keys[category],
+        DehumidifierDriver.state_keys[category][value],
+    )
+
+
+@patch("custom_components.winix.driver.WinixDriver._rpc_attr")
+@pytest.mark.parametrize(
+    ("method", "args", "expected_attr", "expected_value"),
+    [
+        ("set_humidity", [50], "D05", "50"),
+        ("set_humidity", [35], "D05", "35"),
+        ("set_timer", [3], "D15", "3"),
+        ("set_timer", [0], "D15", "0"),
+    ],
+)
+async def test_dehumidifier_rpc(
+    mock_rpc_attr, mock_dehumidifier_driver, method, args, expected_attr, expected_value
+) -> None:
+    """Test DehumidifierDriver direct RPC methods."""
+
+    await getattr(mock_dehumidifier_driver, method)(*args)
+    assert mock_rpc_attr.call_count == 1
+    assert mock_rpc_attr.call_args[0] == (expected_attr, expected_value)
+
+
+@pytest.mark.parametrize(
+    ("mock_dehumidifier_driver_with_payload", "expected"),
+    [
+        ({"D02": "0"}, {"power": "off"}),
+        ({"D02": "1"}, {"power": "on"}),
+        ({"D02": "2"}, {"power": "auto-dry"}),
+        ({"D03": "01"}, {"mode": "auto"}),
+        ({"D03": "02"}, {"mode": "manual"}),
+        ({"D04": "01"}, {"airflow": "high"}),
+        ({"D10": "55"}, {"current_humidity": 55}),
+        ({"D05": "50"}, {"target_humidity": 50}),
+        ({"D15": "3"}, {"timer": 3}),
+        ({"D11": "1"}, {"water_tank": "on"}),
+    ],
+    indirect=["mock_dehumidifier_driver_with_payload"],
+)
+async def test_dehumidifier_get_state(mock_dehumidifier_driver_with_payload, expected) -> None:
+    """Test get_state for DehumidifierDriver."""
+
+    state = await mock_dehumidifier_driver_with_payload.get_state()
     assert state == expected


### PR DESCRIPTION
Related Issue, PR: #151, #154

This PR is the third split from PR #154. It contains only the DehumidifierDriver and its related unit tests. Since the device wrapper and the HA entity implementation for the dehumidifier are not yet included, there should be no impact on the air purifier.

29 unit tests have been added, for a total of 109 passing tests.

``` bash
$ uv run --python 3.13 --with pytest-homeassistant-custom-component --with winix --with pycryptodome   pytest tests/ -p asyncio --asyncio-mode=auto
Test session starts (platform: linux, Python 3.13.7, pytest 9.0.0, pytest-sugar 1.0.0)
rootdir: /home/kyet/ws/winix
plugins: asyncio-1.3.0, pytest_freezer-0.4.9, github-actions-annotate-failures-0.3.0, aiohttp-1.1.0, syrupy-5.0.0, xdist-3.8.0, timeout-2.4.0, cov-7.0.0, sugar-1.0.0, respx-0.22.0, requests-mock-1.12.1, unordered-0.7.0, anyio-4.13.0, homeassistant-custom-component-0.13.316, picked-0.5.1, socket-0.7.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 109 items

 tests/test_config_flow.py ✓✓✓✓                                      4% ▍
 tests/test_device_wrapper.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓             27% ██▋
 tests/test_driver.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓  67% ██████▊
 tests/test_fan.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                  95% █████████▋
 tests/test_sensor.py ✓✓✓✓✓                                        100% ██████████

Results (0.69s):
     109 passed
```