### PR TITLE
Support dehumidifier devices in WinixDeviceWrapper

### DIFF
--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -114,7 +114,8 @@ class NumericPresetModes(StrEnum):
 
 
 class Features:
-    """Additional Winix purifier features."""
+    """Additional Winix device features."""
 
     supports_brightness_level = False
     supports_child_lock = False
+    supports_uv_sanitize = False

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -15,6 +15,11 @@ from .const import (
     ATTR_MODE,
     ATTR_PLASMA,
     ATTR_POWER,
+    ATTR_TARGET_HUMIDITY,
+    ATTR_TIMER,
+    ATTR_UV_SANITIZE,
+    ATTR_WATER_TANK,
+    AUTO_DRY_VALUE,
     MODE_AUTO,
     MODE_MANUAL,
     OFF_VALUE,
@@ -28,7 +33,7 @@ from .const import (
     Features,
     NumericPresetModes,
 )
-from .driver import AirPurifierDriver, WinixDriver
+from .driver import AirPurifierDriver, DehumidifierDriver
 
 
 @dataclasses.dataclass
@@ -49,12 +54,14 @@ def _select_driver(
     device_stub: MyWinixDeviceStub,
     client: aiohttp.ClientSession,
     identity_id: str,
-) -> WinixDriver:
+) -> AirPurifierDriver | DehumidifierDriver:
     """Return the driver that matches the device's product group."""
 
     product_group = (device_stub.product_group or "").casefold()
     if product_group.startswith("air"):
         return AirPurifierDriver(device_stub.id, client, identity_id)
+    elif product_group.startswith("deh"):
+        return DehumidifierDriver(device_stub.id, client, identity_id)
 
     raise ValueError(
         f"Unsupported product_group '{device_stub.product_group}' for device {device_stub.alias}"
@@ -89,6 +96,9 @@ class WinixDeviceWrapper:
         self._logger = logger
         self._child_lock_on: bool | None = None
         self._brightness_level = None
+        self._uv_sanitize: bool | None = None
+        self._water_tank = False
+        self._auto_dry = False
         self._filter_alarm_duration = filter_alarm_duration_hours
 
         self.device_stub = device_stub
@@ -105,23 +115,38 @@ class WinixDeviceWrapper:
         """Update the supported features based on the current state."""
         self._features.supports_brightness_level = self.brightness_level is not None
         self._features.supports_child_lock = self.is_child_lock_on is not None
+        self._features.supports_uv_sanitize = self.is_uv_sanitize_on is not None
 
     async def update(self) -> None:
         """Update the device data."""
         self._state = await self._driver.get_state()
         self._update_common_flags()
-        self._update_air_purifier_flags()
-
-        self._logger.debug(
-            "%s: updated on=%s, auto=%s, manual=%s, sleep=%s, airflow=%s, plasma=%s",
-            self._alias,
-            self._on,
-            self._auto,
-            self._manual,
-            self._sleep,
-            self._state.get(ATTR_AIRFLOW),
-            self._plasma_on,
-        )
+        if self.is_air_purifier:
+            self._update_air_purifier_flags()
+            self._logger.debug(
+                "%s: updated on=%s, auto=%s, manual=%s, sleep=%s, "
+                "airflow=%s, plasma=%s",
+                self._alias,
+                self._on,
+                self._auto,
+                self._manual,
+                self._sleep,
+                self._state.get(ATTR_AIRFLOW),
+                self._plasma_on,
+            )
+        elif self.is_dehumidifier:
+            self._update_dehumidifier_flags()
+            self._logger.debug(
+                "%s: updated on=%s, auto_dry=%s, mode=%s, airflow=%s, "
+                "uv_sanitize=%s, water_tank=%s",
+                self._alias,
+                self._on,
+                self._auto_dry,
+                self._state.get(ATTR_MODE),
+                self._state.get(ATTR_AIRFLOW),
+                self._uv_sanitize,
+                self._water_tank,
+            )
 
     def _update_common_flags(self) -> None:
         """Refresh device-common flags from the latest state."""
@@ -149,19 +174,41 @@ class WinixDeviceWrapper:
         if self._state.get(ATTR_AIRFLOW) == AIRFLOW_SLEEP:
             self._sleep = True
 
+    def _update_dehumidifier_flags(self) -> None:
+        """Refresh dehumidifier-only flags from the latest state."""
+        value = self._state.get(ATTR_UV_SANITIZE)
+        self._uv_sanitize = value == ON_VALUE if value is not None else None
+        self._water_tank = self._state.get(ATTR_WATER_TANK) == ON_VALUE
+        self._auto_dry = self._state.get(ATTR_POWER) == AUTO_DRY_VALUE
+
     def get_state(self) -> dict[str, str]:
         """Return the device data."""
         return self._state
 
     @property
     def features(self) -> Features:
-        """Return the purifiers features."""
+        """Return device features."""
         return self._features
+
+    @property
+    def is_air_purifier(self) -> bool:
+        """Return True if this device is an air purifier."""
+        return isinstance(self._driver, AirPurifierDriver)
+
+    @property
+    def is_dehumidifier(self) -> bool:
+        """Return True if this device is a dehumidifier."""
+        return isinstance(self._driver, DehumidifierDriver)
 
     @property
     def is_on(self) -> bool:
         """Return True if the device is powered on."""
         return self._on
+
+    @property
+    def is_auto_dry(self) -> bool:
+        """Return True if the dehumidifier is in auto-dry power state."""
+        return self._auto_dry
 
     @property
     def is_auto(self) -> bool:
@@ -198,14 +245,17 @@ class WinixDeviceWrapper:
             await self._driver.turn_on()
 
     async def async_turn_on(self) -> None:
-        """Turn on the purifier in Auto mode."""
+        """Turn on the device. Air purifiers enter Auto mode; other devices simply power on."""
         await self.async_ensure_on()
-        await self.async_set_mode(MODE_AUTO)
+        if self.is_air_purifier:
+            await self.async_set_mode(MODE_AUTO)
 
     async def async_turn_off(self) -> None:
         """Turn off the device."""
         if self._on:
             self._on = False
+            # Dehumidifiers may transition to AUTO_DRY_VALUE instead;
+            # next refresh reconciles.
             self._state[ATTR_POWER] = OFF_VALUE
 
             self._logger.debug("%s => turned off", self._alias)
@@ -218,34 +268,42 @@ class WinixDeviceWrapper:
         turns it on for Auto mode.
         """
 
-        if mode == MODE_AUTO:
-            if self._auto:
-                return
-            self._auto = True
-            self._manual = False
-            self._sleep = False
-            self._state[ATTR_MODE] = MODE_AUTO
-            self._state[ATTR_AIRFLOW] = (
-                AIRFLOW_LOW  # Something other than AIRFLOW_SLEEP
-            )
-
-            self._logger.debug("%s => set mode=auto", self._alias)
-            await self._driver.auto()
-        elif mode == MODE_MANUAL:
-            if self._manual:
-                return
-            self._manual = True
-            self._auto = False
-            self._sleep = False
-            self._state[ATTR_MODE] = MODE_MANUAL
-            self._state[ATTR_AIRFLOW] = (
-                AIRFLOW_LOW  # Something other than AIRFLOW_SLEEP
-            )
-
-            self._logger.debug("%s => set mode=manual", self._alias)
-            await self._driver.manual()
-        else:
+        if mode not in self._driver.state_keys[ATTR_MODE]:
             self._logger.error("%s => unsupported mode=%s", self._alias, mode)
+            return
+
+        if self.is_air_purifier:
+            if mode == MODE_AUTO:
+                if self._auto:
+                    return
+                self._auto = True
+                self._manual = False
+                self._sleep = False
+                self._state[ATTR_MODE] = MODE_AUTO
+                self._state[ATTR_AIRFLOW] = (
+                    AIRFLOW_LOW  # Something other than AIRFLOW_SLEEP
+                )
+
+                self._logger.debug("%s => set mode=auto", self._alias)
+                await self._driver.auto()
+            elif mode == MODE_MANUAL:
+                if self._manual:
+                    return
+                self._manual = True
+                self._auto = False
+                self._sleep = False
+                self._state[ATTR_MODE] = MODE_MANUAL
+                self._state[ATTR_AIRFLOW] = (
+                    AIRFLOW_LOW  # Something other than AIRFLOW_SLEEP
+                )
+
+                self._logger.debug("%s => set mode=manual", self._alias)
+                await self._driver.manual()
+        elif self.is_dehumidifier:
+            if self._state.get(ATTR_MODE) == mode:
+                return
+            await self._driver.set_mode(mode)
+            self._state[ATTR_MODE] = mode
 
     async def async_plasmawave_on(self, force: bool = False) -> None:
         """Turn on plasma wave."""
@@ -326,16 +384,22 @@ class WinixDeviceWrapper:
             await self._driver.sleep()
 
     async def async_set_speed(self, speed) -> None:
-        """Turn the purifier on, put it in Manual mode and set the speed."""
+        """Set the device fan speed."""
 
-        self._state[ATTR_AIRFLOW] = speed
+        if self.is_air_purifier:
+            self._state[ATTR_AIRFLOW] = speed
 
-        # Setting speed requires the fan to be in manual mode
-        await self.async_ensure_on()
-        await self.async_set_mode(MODE_MANUAL)
+            # Setting speed requires the fan to be in manual mode
+            await self.async_ensure_on()
+            await self.async_set_mode(MODE_MANUAL)
 
-        self._logger.debug("%s => set speed=%s", self._alias, speed)
-        await getattr(self._driver, speed)()
+            self._logger.debug("%s => set speed=%s", self._alias, speed)
+            await getattr(self._driver, speed)()
+        elif self.is_dehumidifier:
+            if self._state.get(ATTR_AIRFLOW) == speed:
+                return
+            await self._driver.set_fan_speed(speed)
+            self._state[ATTR_AIRFLOW] = speed
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Turn the purifier on and put it in the new preset mode."""
@@ -369,3 +433,47 @@ class WinixDeviceWrapper:
         elif preset_mode == PRESET_MODE_MANUAL_PLASMA_OFF:
             await self.async_set_mode(MODE_MANUAL)
             await self.async_plasmawave_off(True)
+
+    @property
+    def is_uv_sanitize_on(self) -> bool | None:
+        """Return if UV sanitize is on."""
+        return self._uv_sanitize
+
+    async def async_uv_sanitize_on(self) -> bool:
+        """Turn on UV sanitize."""
+        if not self._features.supports_uv_sanitize or self._uv_sanitize:
+            return False
+        await self._driver.uv_sanitize_on()
+        self._uv_sanitize = True
+        self._state[ATTR_UV_SANITIZE] = ON_VALUE
+        return True
+
+    async def async_uv_sanitize_off(self) -> bool:
+        """Turn off UV sanitize."""
+        if not self._features.supports_uv_sanitize or not self._uv_sanitize:
+            return False
+        await self._driver.uv_sanitize_off()
+        self._uv_sanitize = False
+        self._state[ATTR_UV_SANITIZE] = OFF_VALUE
+        return True
+
+    @property
+    def is_water_tank_available(self) -> bool:
+        """Return True if the water tank is not full and not detached."""
+        return not self._water_tank
+
+    async def async_set_humidity(self, humidity: int) -> bool:
+        """Set the target humidity (35-70 %, 5 % steps)."""
+        if self._state.get(ATTR_TARGET_HUMIDITY) == humidity:
+            return False
+        await self._driver.set_humidity(humidity)
+        self._state[ATTR_TARGET_HUMIDITY] = humidity
+        return True
+
+    async def async_set_timer(self, hours: int) -> bool:
+        """Set the dehumidifier timer (0 = off, 1-24 hours)."""
+        if self._state.get(ATTR_TIMER) == hours:
+            return False
+        await self._driver.set_timer(hours)
+        self._state[ATTR_TIMER] = hours
+        return True

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -155,7 +155,7 @@ class WinixDeviceWrapper:
 
     @property
     def is_on(self) -> bool:
-        """Return if the purifier is on."""
+        """Return True if the device is powered on."""
         return self._on
 
     @property
@@ -184,7 +184,7 @@ class WinixDeviceWrapper:
         return self._filter_alarm_duration
 
     async def async_ensure_on(self) -> None:
-        """Turn on the purifier."""
+        """Ensure the device is powered on."""
         if not self._on:
             self._on = True
             self._state[ATTR_POWER] = ON_VALUE
@@ -198,7 +198,7 @@ class WinixDeviceWrapper:
         await self.async_set_mode(MODE_AUTO)
 
     async def async_turn_off(self) -> None:
-        """Turn off the purifier."""
+        """Turn off the device."""
         if self._on:
             self._on = False
             self._state[ATTR_POWER] = OFF_VALUE

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -109,29 +109,8 @@ class WinixDeviceWrapper:
     async def update(self) -> None:
         """Update the device data."""
         self._state = await self._driver.get_state()
-        self._auto = self._manual = self._sleep = self._plasma_on = False
-
-        self._on = self._state.get(ATTR_POWER) == ON_VALUE
-        self._plasma_on = self._state.get(ATTR_PLASMA) == ON_VALUE
-
-        value = self._state.get(ATTR_CHILD_LOCK)
-        self._child_lock_on = value == ON_VALUE if value is not None else None
-
-        self._brightness_level = self._state.get(ATTR_BRIGHTNESS_LEVEL)
-
-        # Sleep: airflow=sleep, mode can be manual
-        # Auto: mode=auto, airflow can be anything
-        # Low: manual+low
-
-        if self._state.get(ATTR_MODE) == MODE_AUTO:
-            self._auto = True
-            self._manual = False
-        elif self._state.get(ATTR_MODE) == MODE_MANUAL:
-            self._auto = False
-            self._manual = True
-
-        if self._state.get(ATTR_AIRFLOW) == AIRFLOW_SLEEP:
-            self._sleep = True
+        self._update_common_flags()
+        self._update_air_purifier_flags()
 
         self._logger.debug(
             "%s: updated on=%s, auto=%s, manual=%s, sleep=%s, airflow=%s, plasma=%s",
@@ -143,6 +122,32 @@ class WinixDeviceWrapper:
             self._state.get(ATTR_AIRFLOW),
             self._plasma_on,
         )
+
+    def _update_common_flags(self) -> None:
+        """Refresh device-common flags from the latest state."""
+        self._on = self._state.get(ATTR_POWER) == ON_VALUE
+        self._plasma_on = self._state.get(ATTR_PLASMA) == ON_VALUE
+
+        value = self._state.get(ATTR_CHILD_LOCK)
+        self._child_lock_on = value == ON_VALUE if value is not None else None
+
+        self._brightness_level = self._state.get(ATTR_BRIGHTNESS_LEVEL)
+
+    def _update_air_purifier_flags(self) -> None:
+        """Refresh air-purifier-only flags from the latest state."""
+        self._auto = self._manual = self._sleep = False
+
+        # Sleep: airflow=sleep, mode can be manual
+        # Auto: mode=auto, airflow can be anything
+        # Low: manual+low
+
+        if self._state.get(ATTR_MODE) == MODE_AUTO:
+            self._auto = True
+        elif self._state.get(ATTR_MODE) == MODE_MANUAL:
+            self._manual = True
+
+        if self._state.get(ATTR_AIRFLOW) == AIRFLOW_SLEEP:
+            self._sleep = True
 
     def get_state(self) -> dict[str, str]:
         """Return the device data."""

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -195,7 +195,7 @@ class WinixDeviceWrapper:
     async def async_turn_on(self) -> None:
         """Turn on the purifier in Auto mode."""
         await self.async_ensure_on()
-        await self.async_auto()
+        await self.async_set_mode(MODE_AUTO)
 
     async def async_turn_off(self) -> None:
         """Turn off the purifier."""
@@ -206,14 +206,16 @@ class WinixDeviceWrapper:
             self._logger.debug("%s => turned off", self._alias)
             await self._driver.turn_off()
 
-    async def async_auto(self) -> None:
-        """Put the purifier in Auto mode with Low airflow.
+    async def async_set_mode(self, mode: str) -> None:
+        """Set the operating mode. Accepts device-specific mode constants.
 
         Plasma state is left unchanged. The Winix server seems to sometimes
         turns it on for Auto mode.
         """
 
-        if not self._auto:
+        if mode == MODE_AUTO:
+            if self._auto:
+                return
             self._auto = True
             self._manual = False
             self._sleep = False
@@ -224,6 +226,21 @@ class WinixDeviceWrapper:
 
             self._logger.debug("%s => set mode=auto", self._alias)
             await self._driver.auto()
+        elif mode == MODE_MANUAL:
+            if self._manual:
+                return
+            self._manual = True
+            self._auto = False
+            self._sleep = False
+            self._state[ATTR_MODE] = MODE_MANUAL
+            self._state[ATTR_AIRFLOW] = (
+                AIRFLOW_LOW  # Something other than AIRFLOW_SLEEP
+            )
+
+            self._logger.debug("%s => set mode=manual", self._alias)
+            await self._driver.manual()
+        else:
+            self._logger.error("%s => unsupported mode=%s", self._alias, mode)
 
     async def async_plasmawave_on(self, force: bool = False) -> None:
         """Turn on plasma wave."""
@@ -290,21 +307,6 @@ class WinixDeviceWrapper:
         self._state[ATTR_BRIGHTNESS_LEVEL] = value
         return True
 
-    async def async_manual(self) -> None:
-        """Put the purifier in Manual mode with Low airflow. Plasma state is left unchanged."""
-
-        if not self._manual:
-            self._manual = True
-            self._auto = False
-            self._sleep = False
-            self._state[ATTR_MODE] = MODE_MANUAL
-            self._state[ATTR_AIRFLOW] = (
-                AIRFLOW_LOW  # Something other than AIRFLOW_SLEEP
-            )
-
-            self._logger.debug("%s => set mode=manual", self._alias)
-            await self._driver.manual()
-
     async def async_sleep(self) -> None:
         """Turn the purifier in Manual mode with Sleep airflow. Plasma state is left unchanged."""
 
@@ -325,7 +327,7 @@ class WinixDeviceWrapper:
 
         # Setting speed requires the fan to be in manual mode
         await self.async_ensure_on()
-        await self.async_manual()
+        await self.async_set_mode(MODE_MANUAL)
 
         self._logger.debug("%s => set speed=%s", self._alias, speed)
         await getattr(self._driver, speed)()
@@ -351,14 +353,14 @@ class WinixDeviceWrapper:
         if preset_mode == PRESET_MODE_SLEEP:
             await self.async_sleep()
         elif preset_mode == PRESET_MODE_AUTO:
-            await self.async_auto()
+            await self.async_set_mode(MODE_AUTO)
             await self.async_plasmawave_on()
         elif preset_mode == PRESET_MODE_AUTO_PLASMA_OFF:
-            await self.async_auto()
+            await self.async_set_mode(MODE_AUTO)
             await self.async_plasmawave_off(True)
         elif preset_mode == PRESET_MODE_MANUAL:
-            await self.async_manual()
+            await self.async_set_mode(MODE_MANUAL)
             await self.async_plasmawave_on()
         elif preset_mode == PRESET_MODE_MANUAL_PLASMA_OFF:
-            await self.async_manual()
+            await self.async_set_mode(MODE_MANUAL)
             await self.async_plasmawave_off(True)

--- a/tests/common.py
+++ b/tests/common.py
@@ -104,6 +104,28 @@ def build_mock_wrapper(index: Number = 0) -> WinixDeviceWrapper:
     )
 
 
+def build_mock_dehumidifier_wrapper(index: Number = 0) -> WinixDeviceWrapper:
+    """Return a mocked WinixDeviceWrapper instance configured as a dehumidifier."""
+    client = Mock()
+
+    device_stub = Mock()
+    device_stub.mac = f"f190d35456d{index}"
+    device_stub.alias = f"Dehumidifier{index}"
+    device_stub.product_group = "Deh01"
+
+    logger = Mock()
+    logger.debug = Mock()
+    logger.warning = Mock()
+
+    return WinixDeviceWrapper(
+        client,
+        device_stub,
+        DEFAULT_FILTER_ALARM_DURATION_HOURS,
+        logger,
+        "test_identity_id",
+    )
+
+
 def build_fake_manager(wrapper_count: Number) -> WinixManager:
     """Return a mocked WinixManager instance."""
     wrappers = []

--- a/tests/test_device_wrapper.py
+++ b/tests/test_device_wrapper.py
@@ -8,12 +8,17 @@ from custom_components.winix.const import (
     AIRFLOW_HIGH,
     AIRFLOW_LOW,
     AIRFLOW_SLEEP,
+    AIRFLOW_TURBO,
     ATTR_AIRFLOW,
     ATTR_MODE,
     ATTR_PLASMA,
     ATTR_POWER,
+    ATTR_TARGET_HUMIDITY,
+    ATTR_TIMER,
+    AUTO_DRY_VALUE,
     DEFAULT_FILTER_ALARM_DURATION_HOURS,
     MODE_AUTO,
+    MODE_CONTINUOUS,
     MODE_MANUAL,
     OFF_VALUE,
     ON_VALUE,
@@ -26,9 +31,10 @@ from custom_components.winix.const import (
 )
 from custom_components.winix.device_wrapper import WinixDeviceWrapper
 
-from .common import build_mock_wrapper  # noqa: TID251
+from .common import build_mock_dehumidifier_wrapper, build_mock_wrapper  # noqa: TID251
 
 AirPurifierDriver_TypeName = "custom_components.winix.driver.AirPurifierDriver"
+DehumidifierDriver_TypeName = "custom_components.winix.driver.DehumidifierDriver"
 
 
 @pytest.mark.parametrize(
@@ -361,3 +367,122 @@ async def test_async_set_preset_mode_invalid() -> None:
 
     with pytest.raises(ValueError):
         await wrapper.async_set_preset_mode("INVALID_PRESET")
+
+
+async def test_async_set_mode_dehumidifier() -> None:
+    """Test setting the dehumidifier operating mode via the unified async_set_mode."""
+
+    with patch(f"{DehumidifierDriver_TypeName}.set_mode") as set_mode:
+        wrapper = build_mock_dehumidifier_wrapper()
+
+        await wrapper.async_set_mode(MODE_AUTO)
+        set_mode.assert_called_once_with(MODE_AUTO)
+        assert wrapper.get_state().get(ATTR_MODE) == MODE_AUTO
+
+        # Same value -> no-op
+        await wrapper.async_set_mode(MODE_AUTO)
+        assert set_mode.call_count == 1
+
+        # New value -> sends command
+        await wrapper.async_set_mode(MODE_CONTINUOUS)
+        assert set_mode.call_count == 2
+        assert wrapper.get_state().get(ATTR_MODE) == MODE_CONTINUOUS
+
+
+async def test_async_set_mode_dehumidifier_unsupported() -> None:
+    """Unsupported dehumidifier modes should be ignored without raising."""
+
+    with patch(f"{DehumidifierDriver_TypeName}.set_mode") as set_mode:
+        wrapper = build_mock_dehumidifier_wrapper()
+
+        await wrapper.async_set_mode("not-a-real-mode")
+
+        assert set_mode.call_count == 0
+        assert wrapper.get_state().get(ATTR_MODE) is None
+
+
+async def test_async_set_speed_dehumidifier() -> None:
+    """Test setting the dehumidifier fan speed via the unified async_set_speed."""
+
+    with patch(f"{DehumidifierDriver_TypeName}.set_fan_speed") as set_fan_speed:
+        wrapper = build_mock_dehumidifier_wrapper()
+
+        await wrapper.async_set_speed(AIRFLOW_HIGH)
+        set_fan_speed.assert_called_once_with(AIRFLOW_HIGH)
+        assert wrapper.get_state().get(ATTR_AIRFLOW) == AIRFLOW_HIGH
+
+        # Same value -> no-op
+        await wrapper.async_set_speed(AIRFLOW_HIGH)
+        assert set_fan_speed.call_count == 1
+
+        # New value -> sends command
+        await wrapper.async_set_speed(AIRFLOW_TURBO)
+        assert set_fan_speed.call_count == 2
+        assert wrapper.get_state().get(ATTR_AIRFLOW) == AIRFLOW_TURBO
+
+
+async def test_async_set_humidity() -> None:
+    """Test setting the dehumidifier target humidity."""
+
+    with patch(f"{DehumidifierDriver_TypeName}.set_humidity") as set_humidity:
+        wrapper = build_mock_dehumidifier_wrapper()
+
+        assert await wrapper.async_set_humidity(50) is True
+        set_humidity.assert_called_once_with(50)
+        assert wrapper.get_state().get(ATTR_TARGET_HUMIDITY) == 50
+
+        # Same value -> no-op
+        assert await wrapper.async_set_humidity(50) is False
+        assert set_humidity.call_count == 1
+
+        # New value -> sends command
+        assert await wrapper.async_set_humidity(60) is True
+        assert set_humidity.call_count == 2
+        assert wrapper.get_state().get(ATTR_TARGET_HUMIDITY) == 60
+
+
+async def test_async_set_timer() -> None:
+    """Test setting the dehumidifier timer."""
+
+    with patch(f"{DehumidifierDriver_TypeName}.set_timer") as set_timer:
+        wrapper = build_mock_dehumidifier_wrapper()
+
+        # First call should send the command
+        assert await wrapper.async_set_timer(3) is True
+        set_timer.assert_called_once_with(3)
+        assert wrapper.get_state().get(ATTR_TIMER) == 3
+
+        # Calling with the same value should be a no-op
+        assert await wrapper.async_set_timer(3) is False
+        assert set_timer.call_count == 1
+
+        # A different value should send the command again
+        assert await wrapper.async_set_timer(0) is True
+        assert set_timer.call_count == 2
+        assert wrapper.get_state().get(ATTR_TIMER) == 0
+
+
+@pytest.mark.parametrize(
+    ("power_value", "is_on", "is_auto_dry"),
+    [
+        (None, False, False),
+        (OFF_VALUE, False, False),
+        (ON_VALUE, True, False),
+        (AUTO_DRY_VALUE, False, True),
+    ],
+)
+async def test_dehumidifier_auto_dry_flag(
+    power_value, is_on, is_auto_dry
+) -> None:
+    """Auto-dry power state is exposed as a dedicated flag."""
+
+    mock_state = {ATTR_POWER: power_value} if power_value is not None else {}
+    with patch(
+        f"{DehumidifierDriver_TypeName}.get_state",
+        AsyncMock(return_value=mock_state),
+    ):
+        wrapper = build_mock_dehumidifier_wrapper()
+        await wrapper.update()
+
+        assert wrapper.is_on is is_on
+        assert wrapper.is_auto_dry is is_auto_dry

--- a/tests/test_device_wrapper.py
+++ b/tests/test_device_wrapper.py
@@ -143,22 +143,22 @@ async def test_async_turn_on() -> None:
     wrapper = build_mock_wrapper()
 
     wrapper.async_ensure_on = AsyncMock()
-    wrapper.async_auto = AsyncMock()
+    wrapper.async_set_mode = AsyncMock()
 
     await wrapper.async_turn_on()
 
     assert wrapper.async_ensure_on.call_count == 1
-    assert wrapper.async_auto.call_count == 1
+    wrapper.async_set_mode.assert_called_once_with(MODE_AUTO)
 
 
-async def test_async_auto() -> None:
+async def test_async_set_mode_auto() -> None:
     """Test setting auto mode."""
 
-    # async_auto does not need the device to be turned on
+    # async_set_mode does not need the device to be turned on
     with patch(f"{AirPurifierDriver_TypeName}.auto") as auto:
         wrapper = build_mock_wrapper()
 
-        await wrapper.async_auto()
+        await wrapper.async_set_mode(MODE_AUTO)
         assert auto.call_count == 1
 
         assert wrapper.is_auto
@@ -167,7 +167,7 @@ async def test_async_auto() -> None:
         assert not wrapper.is_sleep
         assert wrapper.get_state().get(ATTR_AIRFLOW) == AIRFLOW_LOW
 
-        await wrapper.async_auto()  # Calling again should not do anything
+        await wrapper.async_set_mode(MODE_AUTO)  # Calling again should not do anything
         assert auto.call_count == 1
 
 
@@ -203,14 +203,14 @@ async def test_async_plasmawave_on_off() -> None:
         assert plasmawave_off.call_count == 1
 
 
-async def test_async_manual() -> None:
+async def test_async_set_mode_manual() -> None:
     """Test setting manual mode."""
 
-    # async_manual does not need the device to be turned on
+    # async_set_mode does not need the device to be turned on
     with patch(f"{AirPurifierDriver_TypeName}.manual") as manual:
         wrapper = build_mock_wrapper()
 
-        await wrapper.async_manual()
+        await wrapper.async_set_mode(MODE_MANUAL)
         assert manual.call_count == 1
 
         assert not wrapper.is_auto
@@ -220,8 +220,25 @@ async def test_async_manual() -> None:
         assert wrapper.get_state().get(ATTR_MODE) == MODE_MANUAL
         assert wrapper.get_state().get(ATTR_AIRFLOW) == AIRFLOW_LOW
 
-        await wrapper.async_manual()  # Calling again should not do anything
+        await wrapper.async_set_mode(MODE_MANUAL)  # Calling again should not do anything
         assert manual.call_count == 1
+
+
+async def test_async_set_mode_unsupported() -> None:
+    """Unsupported mode values should be ignored without raising."""
+
+    with (
+        patch(f"{AirPurifierDriver_TypeName}.auto") as auto,
+        patch(f"{AirPurifierDriver_TypeName}.manual") as manual,
+    ):
+        wrapper = build_mock_wrapper()
+
+        await wrapper.async_set_mode("not-a-real-mode")
+
+        assert auto.call_count == 0
+        assert manual.call_count == 0
+        assert not wrapper.is_auto
+        assert not wrapper.is_manual
 
 
 async def test_async_sleep() -> None:
@@ -246,7 +263,7 @@ async def test_async_sleep() -> None:
 
 
 async def test_async_set_speed() -> None:
-    """Test setting speed."""
+    """Test setting fan speed."""
 
     with (
         patch(f"{AirPurifierDriver_TypeName}.turn_on"),
@@ -307,8 +324,7 @@ async def test_async_set_preset_mode(
 
     wrapper.async_ensure_on = AsyncMock()
     wrapper.async_sleep = AsyncMock()
-    wrapper.async_auto = AsyncMock()
-    wrapper.async_manual = AsyncMock()
+    wrapper.async_set_mode = AsyncMock()
     wrapper.async_plasmawave_off = AsyncMock()
     wrapper.async_plasmawave_on = AsyncMock()
 
@@ -316,8 +332,11 @@ async def test_async_set_preset_mode(
     assert wrapper.async_ensure_on.call_count == 1
 
     assert wrapper.async_sleep.call_count == sleep
-    assert wrapper.async_auto.call_count == auto
-    assert wrapper.async_manual.call_count == manual
+    assert wrapper.async_set_mode.call_count == auto + manual
+    if auto:
+        wrapper.async_set_mode.assert_called_once_with(MODE_AUTO)
+    if manual:
+        wrapper.async_set_mode.assert_called_once_with(MODE_MANUAL)
     assert wrapper.async_plasmawave_off.call_count == plasmawave_off
     assert wrapper.async_plasmawave_on.call_count == plasmawave_on
 


### PR DESCRIPTION
Related Issue, PR: https://github.com/iprak/winix/issues/151, https://github.com/iprak/winix/pull/154

This PR is the fourth split from PR #154. It adds dehumidifier support to deivce wrapper, along with a small refactor. If you'd prefer to split it further, I can have the refactoring commits 1~3 reviewed first and move the dehumidifier support (commit 4) to a follow-up PR.

Unlike driver, deivce wrapper is not split by device type (product group) into separate classes. As discussed in the previous PR (https://github.com/iprak/winix/pull/168#issuecomment-4309797626), not only the basic functionality (power/mode/airflow) but also features like child lock, plasma, and brightness are shared across device types. So I kept everything in a single class that handles multiple device types.

On the air purifier side, the interplay between power/mode/airflow is carefully implemented — for example, changing the airflow (speed) automatically switches the mode to manual. The initial dehumidifier implementation does not yet replicate this kind of cross-state behavior. Once the HA entity work is finished, I will test these state interactions on a real device and refine the implementation accordingly.

10 unit tests were added (109 → 119). They all pass.

``` bash
(0db) ~/ws/winix $ uv run --python 3.13 --with pytest-homeassistant-custom-component --with winix --with pycryptodome   pytest tests/ -p asyncio --asyncio-mode=auto
Test session starts (platform: linux, Python 3.13.7, pytest 9.0.0, pytest-sugar 1.0.0)
rootdir: /home/kyet/ws/winix
plugins: asyncio-1.3.0, pytest_freezer-0.4.9, github-actions-annotate-failures-0.3.0, aiohttp-1.1.0, syrupy-5.0.0, xdist-3.8.0, timeout-2.4.0, cov-7.0.0, sugar-1.0.0, respx-0.22.0, requests-mock-1.12.1, unordered-0.7.0, anyio-4.13.0, homeassistant-custom-component-0.13.316, picked-0.5.1, socket-0.7.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 119 items

 tests/test_config_flow.py ✓✓✓✓                                    3% ▍
 tests/test_device_wrapper.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ 33% ███▍
 tests/test_driver.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓ 69% ██████▉
                      ✓                                           70% ███████
 tests/test_fan.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                96% █████████▋
 tests/test_sensor.py ✓✓✓✓✓                                      100% ██████████

Results (0.76s):
     119 passed
```

ruff check also passes.

``` bash
(0db) ~/ws/winix $ ruff check .
All checks passed!
```