### PR TITLE
Prepare HA entity layer and refactor for multi-device support

### DIFF
--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -1,4 +1,4 @@
-"""The Winix Air Purifier component."""
+"""The Winix component."""
 
 from __future__ import annotations
 

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -118,4 +118,5 @@ class Features:
 
     supports_brightness_level = False
     supports_child_lock = False
+    supports_pm25 = False
     supports_uv_sanitize = False

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Winix C545 Air Purifier component."""
+"""Constants for the Winix component."""
 
 from enum import StrEnum, unique
 import logging
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__package__)
 
 WINIX_DOMAIN: Final = "winix"
 
-WINIX_NAME: Final = "Winix Purifier"
+WINIX_NAME: Final = "Winix"
 WINIX_AUTH_RESPONSE: Final = "WinixAuthResponse"
 ATTR_AIRFLOW: Final = "airflow"
 ATTR_AIR_AQI: Final = "aqi"

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -60,7 +60,8 @@ def _select_driver(
     product_group = (device_stub.product_group or "").casefold()
     if product_group.startswith("air"):
         return AirPurifierDriver(device_stub.id, client, identity_id)
-    elif product_group.startswith("deh"):
+
+    if product_group.startswith("deh"):
         return DehumidifierDriver(device_stub.id, client, identity_id)
 
     raise ValueError(

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -14,6 +14,7 @@ from .const import (
     ATTR_CHILD_LOCK,
     ATTR_MODE,
     ATTR_PLASMA,
+    ATTR_PM25,
     ATTR_POWER,
     ATTR_TARGET_HUMIDITY,
     ATTR_TIMER,
@@ -116,6 +117,7 @@ class WinixDeviceWrapper:
         """Update the supported features based on the current state."""
         self._features.supports_brightness_level = self.brightness_level is not None
         self._features.supports_child_lock = self.is_child_lock_on is not None
+        self._features.supports_pm25 = ATTR_PM25 in self._state
         self._features.supports_uv_sanitize = self.is_uv_sanitize_on is not None
 
     async def update(self) -> None:

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import dataclasses
-
 import aiohttp
 
 from .const import (
@@ -35,20 +33,7 @@ from .const import (
     NumericPresetModes,
 )
 from .driver import AirPurifierDriver, DehumidifierDriver
-
-
-@dataclasses.dataclass
-class MyWinixDeviceStub:
-    """Winix device information."""
-
-    id: str
-    mac: str
-    alias: str
-    location_code: str
-    filter_replace_date: str
-    model: str
-    sw_version: str
-    product_group: str
+from .stub import MyWinixDeviceStub
 
 
 def _select_driver(

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -19,6 +19,7 @@ from .const import (
     ATTR_UV_SANITIZE,
     ATTR_WATER_TANK,
     AUTO_DRY_VALUE,
+    DEFAULT_FILTER_ALARM_DURATION_HOURS,
     MODE_AUTO,
     MODE_MANUAL,
     OFF_VALUE,
@@ -33,6 +34,7 @@ from .const import (
     NumericPresetModes,
 )
 from .driver import AirPurifierDriver, DehumidifierDriver
+from .helpers import Helpers
 from .stub import MyWinixDeviceStub
 
 
@@ -64,12 +66,12 @@ class WinixDeviceWrapper:
         self,
         client: aiohttp.ClientSession,
         device_stub: MyWinixDeviceStub,
-        filter_alarm_duration_hours: int,
         logger,
         identity_id: str,
     ) -> None:
         """Initialize the wrapper."""
 
+        self._client = client
         self._driver = _select_driver(device_stub, client, identity_id)
 
         # Start as empty object in case fan was operated before it got updated
@@ -86,17 +88,22 @@ class WinixDeviceWrapper:
         self._uv_sanitize: bool | None = None
         self._water_tank = False
         self._auto_dry = False
-        self._filter_alarm_duration = filter_alarm_duration_hours
+        # Air purifiers refresh this in async_initialize(); dehumidifiers leave the
+        # default since the API does not expose filter_hour for them.
+        self._filter_alarm_duration = DEFAULT_FILTER_ALARM_DURATION_HOURS
 
         self.device_stub = device_stub
         self._alias = device_stub.alias
         self._features = Features()
 
-        logger.debug(
-            "%s: created device with filter_alarm_duration=%d",
-            self._alias,
-            filter_alarm_duration_hours,
-        )
+        logger.debug("%s: created device", self._alias)
+
+    async def async_initialize(self, token: str, uuid: str) -> None:
+        """Fetch product-type-specific initialization data."""
+        if self.is_air_purifier:
+            self._filter_alarm_duration = await Helpers.get_filter_alarm_duration(
+                self._client, token, uuid, self.device_stub.id
+            )
 
     def update_features(self) -> None:
         """Update the supported features based on the current state."""

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -1,4 +1,4 @@
-"""The Winix Air Purifier component."""
+"""Winix device wrapper."""
 
 from __future__ import annotations
 

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -1,4 +1,4 @@
-"""Winix Air Purifier Device."""
+"""Winix Air Purifier fan entity."""
 
 from __future__ import annotations
 

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -48,7 +48,9 @@ async def async_setup_entry(
     """Set up the Winix air purifiers."""
     manager = entry.runtime_data
     entities = [
-        WinixPurifier(wrapper, manager) for wrapper in manager.get_device_wrappers()
+        WinixPurifier(wrapper, manager)
+        for wrapper in manager.get_device_wrappers()
+        if wrapper.is_air_purifier
     ]
     async_add_entities(entities)
 

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -25,7 +25,7 @@ from .const import (
     LOGGER,
     WINIX_DOMAIN,
 )
-from .device_wrapper import MyWinixDeviceStub
+from .stub import MyWinixDeviceStub
 
 # Winix rotated their Cognito app client on 2026-04-16. The old client ID
 # (14og512b9u20b8vrdm55d8empi) is dead. Patch the pip package constants before

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -1,4 +1,4 @@
-"""The Winix Air Purifier component."""
+"""Winix integration helpers."""
 
 from __future__ import annotations
 

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -137,18 +137,23 @@ class WinixManager(DataUpdateCoordinator):
 
         if device_stubs:
             for device_stub in device_stubs:
-                filter_alarm_duration = await Helpers.get_filter_alarm_duration(
-                    self._client, token, uuid, device_stub.id
-                )
-                self._device_wrappers.append(
-                    WinixDeviceWrapper(
-                        self._client,
-                        device_stub,
-                        filter_alarm_duration,
-                        LOGGER,
-                        identity_id,
+                try:
+                    wrapper = WinixDeviceWrapper(
+                        self._client, device_stub, LOGGER, identity_id
                     )
-                )
+                except ValueError as err:
+                    LOGGER.warning("Skipping device: %s", err)
+                    continue
+
+                try:
+                    await wrapper.async_initialize(token, uuid)
+                except Exception as err:
+                    LOGGER.warning(
+                        "Failed to initialize device %s: %s", device_stub.alias, err
+                    )
+                    raise
+
+                self._device_wrappers.append(wrapper)
 
             LOGGER.info("%d purifiers found", len(self._device_wrappers))
         else:

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -155,9 +155,9 @@ class WinixManager(DataUpdateCoordinator):
 
                 self._device_wrappers.append(wrapper)
 
-            LOGGER.info("%d purifiers found", len(self._device_wrappers))
+            LOGGER.info("%d devices found", len(self._device_wrappers))
         else:
-            LOGGER.info("No purifiers found")
+            LOGGER.info("No devices found")
 
     def get_device_wrappers(self) -> list[WinixDeviceWrapper]:
         """Return the device wrapper objects."""

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -1,4 +1,4 @@
-"""The Winix C545 Air Purifier component."""
+"""The Winix component."""
 
 from __future__ import annotations
 

--- a/custom_components/winix/manifest.json
+++ b/custom_components/winix/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "winix",
-  "name": "Winix Air Purifier",
+  "name": "Winix",
   "documentation": "https://github.com/iprak/winix",
   "requirements": [
     "winix==0.3.0",

--- a/custom_components/winix/select.py
+++ b/custom_components/winix/select.py
@@ -26,6 +26,7 @@ class WinixSelectEntityDescription(SelectEntityDescription):
     exists_fn: Callable[[WinixDeviceWrapper], bool]
     current_option_fn: Callable[[WinixDeviceWrapper], str]
     select_option_fn: Callable[[WinixDeviceWrapper, str], Coroutine[Any, Any, Any]]
+    available_fn: Callable[[WinixDeviceWrapper], bool] | None = None
 
 
 def format_brightness_level(value: int | None) -> str:
@@ -57,6 +58,7 @@ SELECT_DESCRIPTIONS: Final[tuple[WinixSelectEntityDescription, ...]] = (
         select_option_fn=lambda device, value: device.async_set_brightness_level(
             parse_brightness_level(value)
         ),
+        available_fn=lambda device: device.is_on,
     ),
 )
 
@@ -77,7 +79,7 @@ async def async_setup_entry(
         if description.exists_fn(wrapper)
     ]
     async_add_entities(entities)
-    LOGGER.info("Added %s selects", len(entities))
+    LOGGER.info("Added %s select entities", len(entities))
 
 
 class WinixSelectEntity(WinixEntity, SelectEntity):
@@ -106,11 +108,12 @@ class WinixSelectEntity(WinixEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Set the entity value."""
-        if await self.entity_description.select_option_fn(self.device_wrapper, option):
-            self.async_write_ha_state()
-            await self.coordinator.async_request_refresh()
+        await self.entity_description.select_option_fn(self.device_wrapper, option)
+        self.async_write_ha_state()
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self.device_wrapper.is_on
+        if self.entity_description.available_fn is not None:
+            return self.entity_description.available_fn(self.device_wrapper)
+        return super().available

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -1,9 +1,9 @@
-"""Winix Air Purfier Air QValue Sensor."""
+"""Winix sensor entities (air quality, filter life)."""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -80,7 +80,8 @@ class WinixSensorEntityDescription(SensorEntityDescription):
     """Describe Winix sensor entity."""
 
     value_fn: Callable[[dict[str, str], WinixDeviceWrapper], StateType]
-    extra_state_attributes_fn: Callable[[dict[str, str]], dict[str, Any]]
+    extra_state_attributes_fn: Callable[[dict[str, str]], dict[str, Any]] | None = None
+    exists_fn: Callable[[WinixDeviceWrapper], bool] = field(default=lambda _: True)
 
 
 SENSOR_DESCRIPTIONS: tuple[WinixSensorEntityDescription, ...] = (
@@ -92,6 +93,7 @@ SENSOR_DESCRIPTIONS: tuple[WinixSensorEntityDescription, ...] = (
         native_unit_of_measurement="qv",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda state, wrapper: state.get(ATTR_AIR_QVALUE),
+        exists_fn=lambda device: device.is_air_purifier,
     ),
     WinixSensorEntityDescription(
         extra_state_attributes_fn=get_filter_replacement_cycle,
@@ -101,22 +103,24 @@ SENSOR_DESCRIPTIONS: tuple[WinixSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=get_filter_life,
+        exists_fn=lambda device: device.is_air_purifier,
     ),
     WinixSensorEntityDescription(
-        extra_state_attributes_fn=None,
         icon="mdi:blur",
         key=SENSOR_AQI,
         name="AQI",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda state, wrapper: state.get(ATTR_AIR_AQI),
+        exists_fn=lambda device: device.is_air_purifier,
     ),
     WinixSensorEntityDescription(
         device_class=SensorDeviceClass.PM25,
-        extra_state_attributes_fn=None,
         key=SENSOR_PM25,
         name="PM 2.5",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         value_fn=lambda state, wrapper: state.get(ATTR_PM25),
+        exists_fn=lambda device: device.is_air_purifier
+        and device.features.supports_pm25,
     ),
 )
 
@@ -133,7 +137,7 @@ async def async_setup_entry(
         WinixSensor(wrapper, manager, description)
         for description in SENSOR_DESCRIPTIONS
         for wrapper in manager.get_device_wrappers()
-        if description.key != SENSOR_PM25 or wrapper.features.supports_pm25
+        if description.exists_fn(wrapper)
     ]
     async_add_entities(entities)
     LOGGER.info("Added %s sensors", len(entities))

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -133,7 +133,7 @@ async def async_setup_entry(
         WinixSensor(wrapper, manager, description)
         for description in SENSOR_DESCRIPTIONS
         for wrapper in manager.get_device_wrappers()
-        if description.key != SENSOR_PM25 or ATTR_PM25 in (wrapper.get_state() or {})
+        if description.key != SENSOR_PM25 or wrapper.features.supports_pm25
     ]
     async_add_entities(entities)
     LOGGER.info("Added %s sensors", len(entities))

--- a/custom_components/winix/strings.json
+++ b/custom_components/winix/strings.json
@@ -7,7 +7,7 @@
           "password": "[%key:common::config_flow::data::password%]"
         },
         "description": "Set up Winix integration. Login with your mobile app credentials.",
-        "title": "Winix Air Purifier"
+        "title": "Winix"
       }
     },
     "error": {

--- a/custom_components/winix/stub.py
+++ b/custom_components/winix/stub.py
@@ -1,0 +1,19 @@
+"""Winix device stub."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class MyWinixDeviceStub:
+    """Winix device information."""
+
+    id: str
+    mac: str
+    alias: str
+    location_code: str
+    filter_replace_date: str
+    model: str
+    sw_version: str
+    product_group: str

--- a/custom_components/winix/translations/en.json
+++ b/custom_components/winix/translations/en.json
@@ -7,7 +7,7 @@
           "password": "Password"
         },
         "description": "Configure the Winix integration by signing in with your mobile app credentials.",
-        "title": "Winix Air Purifier"
+        "title": "Winix"
       }
     },
     "error": {

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Winix Purifier",
+  "name": "Winix",
   "render_readme": true,
   "homeassistant": "2024.8.0"
 }

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,6 @@ from voluptuous.validators import Number
 
 from custom_components.winix.const import (
     DEFAULT_FILTER_ALARM_DURATION,
-    DEFAULT_FILTER_ALARM_DURATION_HOURS,
     WINIX_AUTH_RESPONSE,
     WINIX_DOMAIN,
 )
@@ -96,13 +95,7 @@ def build_mock_wrapper(index: Number = 0) -> WinixDeviceWrapper:
     logger.debug = Mock()
     logger.warning = Mock()
 
-    return WinixDeviceWrapper(
-        client,
-        device_stub,
-        DEFAULT_FILTER_ALARM_DURATION_HOURS,
-        logger,
-        "test_identity_id",
-    )
+    return WinixDeviceWrapper(client, device_stub, logger, "test_identity_id")
 
 
 def build_mock_dehumidifier_wrapper(index: Number = 0) -> WinixDeviceWrapper:
@@ -118,13 +111,7 @@ def build_mock_dehumidifier_wrapper(index: Number = 0) -> WinixDeviceWrapper:
     logger.debug = Mock()
     logger.warning = Mock()
 
-    return WinixDeviceWrapper(
-        client,
-        device_stub,
-        DEFAULT_FILTER_ALARM_DURATION_HOURS,
-        logger,
-        "test_identity_id",
-    )
+    return WinixDeviceWrapper(client, device_stub, logger, "test_identity_id")
 
 
 def build_fake_manager(wrapper_count: Number) -> WinixManager:

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,9 +12,10 @@ from custom_components.winix.const import (
     WINIX_AUTH_RESPONSE,
     WINIX_DOMAIN,
 )
-from custom_components.winix.device_wrapper import MyWinixDeviceStub, WinixDeviceWrapper
+from custom_components.winix.device_wrapper import WinixDeviceWrapper
 from custom_components.winix.fan import WinixPurifier
 from custom_components.winix.manager import WinixManager
+from custom_components.winix.stub import MyWinixDeviceStub
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
-from custom_components.winix.device_wrapper import MyWinixDeviceStub, WinixDeviceWrapper
+from custom_components.winix.device_wrapper import WinixDeviceWrapper
 from custom_components.winix.driver import AirPurifierDriver, DehumidifierDriver
+from custom_components.winix.stub import MyWinixDeviceStub
 
 from .common import TEST_DEVICE_ID  # noqa: TID251
 

--- a/tests/test_device_wrapper.py
+++ b/tests/test_device_wrapper.py
@@ -16,7 +16,6 @@ from custom_components.winix.const import (
     ATTR_TARGET_HUMIDITY,
     ATTR_TIMER,
     AUTO_DRY_VALUE,
-    DEFAULT_FILTER_ALARM_DURATION_HOURS,
     MODE_AUTO,
     MODE_CONTINUOUS,
     MODE_MANUAL,
@@ -357,13 +356,7 @@ async def test_async_set_preset_mode_invalid() -> None:
     logger.debug = Mock()
     logger.warning = Mock()
 
-    wrapper = WinixDeviceWrapper(
-        client,
-        device_stub,
-        DEFAULT_FILTER_ALARM_DURATION_HOURS,
-        logger,
-        "test_identity_id",
-    )
+    wrapper = WinixDeviceWrapper(client, device_stub, logger, "test_identity_id")
 
     with pytest.raises(ValueError):
         await wrapper.async_set_preset_mode("INVALID_PRESET")

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -6,7 +6,6 @@ import pytest
 
 from custom_components.winix.driver import AirPurifierDriver, DehumidifierDriver
 
-
 # ---------------------------------------------------------------------------
 # AirPurifierDriver tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Related Issue, PR: https://github.com/iprak/winix/issues/151, https://github.com/iprak/winix/pull/154

This PR is the fifth split from PR https://github.com/iprak/winix/pull/154. This PR is split from the larger dehumidifier work to keep the upcoming HA entity PR (likely the final one in this series) as a near-pure addition — minimal modifications to existing code, mostly new files and descriptions. The key commit is e1b4cb6. It introduces `exists_fn` into `WinixSensorEntityDescription` and gates all existing sensors (air quality, AQI, PM2.5, filter life) to `is_air_purifier` wrappers only. The same pattern is applied to `fan.py`, and to other platforms.

`f4a07a6` rebrands the integration name from "Winix Air Purifier" to "Winix" across manifest, strings, and module docstrings. The driver and device wrapper layers already support multiple device types through earlier PRs, but the HA entity layer still only covers air purifiers at this point — so it could be argued that this rebrand would be more appropriate after the dehumidifier HA entity is added. Happy to move it if you prefer.

The ruff violations raised in the #168 review are also addressed here.

All 119 tests pass.

``` bash
$ uv run --python 3.13 --with pytest-homeassistant-custom-component --with winix --with pycryptodome pytest tests/ -p asyncio --asyncio-mode=auto
Test session starts (platform: linux, Python 3.13.7, pytest 9.0.0, pytest-sugar 1.0.0)
rootdir: /home/kyet/ws/winix
plugins: asyncio-1.3.0, pytest_freezer-0.4.9, github-actions-annotate-failures-0.3.0, aiohttp-1.1.0, syrupy-5.0.0, xdist-3.8.0, timeout-2.4.0, cov-7.0.0, sugar-1.0.0, respx-0.22.0, requests-mock-1.12.1, unordered-0.7.0, anyio-4.13.0, homeassistant-custom-component-0.13.316, picked-0.5.1, socket-0.7.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None

 tests/test_config_flow.py ✓✓✓✓                                           3% ▍
 tests/test_device_wrapper.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓        32% ███▍
 tests/test_driver.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓        69% ██████▉
 tests/test_fan.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                        95% █████████▋
 tests/test_sensor.py ✓✓✓✓✓                                              100% ██████████

Results (0.72s):
     119 passed
```

ruff check also passes (config derived from https://github.com/home-assistant/core/blob/dev/pyproject.toml)

``` bash
$ ruff check custom_components/winix/*.py tests/*.py
All checks passed!
```