### PR TITLE
Set device_class on timer, and dehumidifier entities

### DIFF
--- a/custom_components/winix/humidifier.py
+++ b/custom_components/winix/humidifier.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from homeassistant.components.humidifier import (
     HumidifierAction,
+    HumidifierDeviceClass,
     HumidifierEntity,
     HumidifierEntityFeature,
 )
@@ -48,6 +49,7 @@ class WinixDehumidifier(WinixEntity, HumidifierEntity):
 
     # https://developers.home-assistant.io/docs/core/entity/humidifier/
     _attr_supported_features = HumidifierEntityFeature.MODES
+    _attr_device_class = HumidifierDeviceClass.DEHUMIDIFIER
 
     _attr_min_humidity = DEHUMIDIFIER_MIN_HUMIDITY
     _attr_max_humidity = DEHUMIDIFIER_MAX_HUMIDITY

--- a/custom_components/winix/icons.json
+++ b/custom_components/winix/icons.json
@@ -8,14 +8,6 @@
 				}
 			}
 		},
-		"humidifier": {
-			"dehumidifier": {
-				"default": "mdi:air-humidifier",
-				"state": {
-					"off": "mdi:air-humidifier-off"
-				}
-			}
-		},
 		"binary_sensor": {
 			"water_tank": {
 				"default": "mdi:water-outline",

--- a/custom_components/winix/number.py
+++ b/custom_components/winix/number.py
@@ -7,10 +7,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.number import (
+    NumberDeviceClass,
     NumberEntity,
     NumberEntityDescription,
     NumberMode,
 )
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -33,12 +35,13 @@ NUMBER_DESCRIPTIONS: tuple[WinixNumberEntityDescription, ...] = (
     WinixNumberEntityDescription(
         key="timer",
         translation_key="timer",
+        device_class=NumberDeviceClass.DURATION,
         icon="mdi:timer-outline",
         native_min_value=0,
         native_max_value=24,
         native_step=1,
         mode=NumberMode.BOX,
-        native_unit_of_measurement="h",
+        native_unit_of_measurement=UnitOfTime.HOURS,
         exists_fn=lambda device: device.is_dehumidifier,
         value_fn=lambda device: (device.get_state() or {}).get(ATTR_TIMER),
         set_value_fn=lambda device, value: device.async_set_timer(round(value)),


### PR DESCRIPTION
My other PR is still under review, and now I'm submitting another one. I'm certainly not trying to be a bother :) Feel free to take your time with the review.

This PR sets the device_class for three entities: dehumidifier, timer, and AQI. As far as I understand and have tested, this PR does not result in any UI changes.

For the dehumidifier, since the default icon when device_class is set matches the icon I had configured, icon.json has been simplified. However, for timer and AQI, the configured icons differ from the defaults, so the icon settings cannot be removed. For the timer, since UnitOfTime.HOURS == "h", the code is functionally identical — it just uses the predefined constant instead.

ruff and unit tests all pass.