### PR TITLE
fix: delay refresh after on off

### DIFF
--- a/custom_components/winix/__init__.py
+++ b/custom_components/winix/__init__.py
@@ -1,7 +1,5 @@
 """The Winix component."""
 
-from __future__ import annotations
-
 from collections.abc import Iterable
 from typing import Final
 

--- a/custom_components/winix/binary_sensor.py
+++ b/custom_components/winix/binary_sensor.py
@@ -1,7 +1,5 @@
 """Winix Binary Sensor."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from dataclasses import dataclass
 

--- a/custom_components/winix/config_flow.py
+++ b/custom_components/winix/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for Winix purifier."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from typing import Any
 

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -1,7 +1,5 @@
 """Winix device wrapper."""
 
-from __future__ import annotations
-
 import aiohttp
 
 from .const import (

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -1,7 +1,5 @@
 """The WinixDriver component."""
 
-from __future__ import annotations
-
 from enum import Enum, unique
 
 import aiohttp
@@ -222,7 +220,11 @@ class AirPurifierDriver(WinixDriver):
         },
         ATTR_CHILD_LOCK: {OFF_VALUE: "0", ON_VALUE: "1"},
         ATTR_PLASMA: {OFF_VALUE: "0", ON_VALUE: "1"},
-        ATTR_AIR_QUALITY: {AIR_QUALITY_GOOD: "01", AIR_QUALITY_FAIR: "02", AIR_QUALITY_POOR: "03"},
+        ATTR_AIR_QUALITY: {
+            AIR_QUALITY_GOOD: "01",
+            AIR_QUALITY_FAIR: "02",
+            AIR_QUALITY_POOR: "03",
+        },
     }
 
     async def turn_off(self) -> None:

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -2,15 +2,17 @@
 
 import asyncio
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 import voluptuous as vol
 
 from homeassistant.components.fan import ENTITY_ID_FORMAT, FanEntity, FanEntityFeature
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HassJob, HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
@@ -36,6 +38,8 @@ from .const import (
 )
 from .device_wrapper import WinixDeviceWrapper
 from .manager import WinixEntity, WinixManager
+
+FAN_ON_OFF_REFRESH_DELAY = 4
 
 
 async def async_setup_entry(
@@ -234,16 +238,24 @@ class WinixPurifier(WinixEntity, FanEntity):
             await self.device_wrapper.async_turn_on()
 
         self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
-
-        # Use coordinator to notify other entities e.g. brightness selection
-        if self.device_wrapper.features.supports_brightness_level:
-            self.coordinator.async_update_listeners()
+        async_call_later(
+            self.hass,
+            FAN_ON_OFF_REFRESH_DELAY,
+            HassJob(self._async_refresh, cancel_on_shutdown=True),
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the purifier."""
         await self.device_wrapper.async_turn_off()
         self.async_write_ha_state()
+        async_call_later(
+            self.hass,
+            FAN_ON_OFF_REFRESH_DELAY,
+            HassJob(self._async_refresh, cancel_on_shutdown=True),
+        )
+
+    async def _async_refresh(self, _: datetime) -> None:
+        """Refresh the purifier state."""
         await self.coordinator.async_request_refresh()
 
         # Use coordinator to notify other entities e.g. brightness selection

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -1,7 +1,5 @@
 """Winix Air Purifier fan entity."""
 
-from __future__ import annotations
-
 import asyncio
 from collections.abc import Mapping
 from typing import Any

--- a/custom_components/winix/helpers.py
+++ b/custom_components/winix/helpers.py
@@ -1,7 +1,5 @@
 """Winix integration helpers."""
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from http import HTTPStatus
 import json

--- a/custom_components/winix/humidifier.py
+++ b/custom_components/winix/humidifier.py
@@ -1,7 +1,5 @@
 """Winix Dehumidifier entity."""
 
-from __future__ import annotations
-
 from typing import Any
 
 from homeassistant.components.humidifier import (
@@ -126,8 +124,12 @@ class WinixDehumidifier(WinixEntity, HumidifierEntity):
 
     async def async_set_humidity(self, humidity: int) -> None:
         """Set target humidity, rounding to nearest 5 % step and clamping to valid range."""
-        humidity = round(humidity / DEHUMIDIFIER_HUMIDITY_STEP) * DEHUMIDIFIER_HUMIDITY_STEP
-        humidity = max(DEHUMIDIFIER_MIN_HUMIDITY, min(DEHUMIDIFIER_MAX_HUMIDITY, humidity))
+        humidity = (
+            round(humidity / DEHUMIDIFIER_HUMIDITY_STEP) * DEHUMIDIFIER_HUMIDITY_STEP
+        )
+        humidity = max(
+            DEHUMIDIFIER_MIN_HUMIDITY, min(DEHUMIDIFIER_MAX_HUMIDITY, humidity)
+        )
         await self.device_wrapper.async_set_humidity(humidity)
         self.async_write_ha_state()
 

--- a/custom_components/winix/manager.py
+++ b/custom_components/winix/manager.py
@@ -1,7 +1,5 @@
 """The Winix component."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 
 from winix import WinixAccount, auth

--- a/custom_components/winix/number.py
+++ b/custom_components/winix/number.py
@@ -1,7 +1,5 @@
 """Winix number entities (e.g. dehumidifier timer)."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any

--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -1,7 +1,5 @@
 """Winix sensor entities (air quality, filter life)."""
 
-from __future__ import annotations
-
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
@@ -119,8 +117,9 @@ SENSOR_DESCRIPTIONS: tuple[WinixSensorEntityDescription, ...] = (
         translation_key="pm2_5",
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         value_fn=lambda state, wrapper: state.get(ATTR_PM25),
-        exists_fn=lambda device: device.is_air_purifier
-        and device.features.supports_pm25,
+        exists_fn=lambda device: (
+            device.is_air_purifier and device.features.supports_pm25
+        ),
     ),
 )
 

--- a/custom_components/winix/stub.py
+++ b/custom_components/winix/stub.py
@@ -1,7 +1,5 @@
 """Winix device stub."""
 
-from __future__ import annotations
-
 import dataclasses
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ def mock_device_wrapper() -> WinixDeviceWrapper:
     device_wrapper.async_plasmawave_on = AsyncMock()
     device_wrapper.async_set_preset_mode = AsyncMock()
     device_wrapper.async_set_speed = AsyncMock()
+    device_wrapper.async_turn_off = AsyncMock()
     device_wrapper.async_turn_on = AsyncMock()
 
     return device_wrapper
@@ -97,7 +98,9 @@ def mock_airpurifier_driver() -> AirPurifierDriver:
 
 
 @pytest.fixture
-def mock_airpurifier_driver_with_payload(request: pytest.FixtureRequest) -> AirPurifierDriver:
+def mock_airpurifier_driver_with_payload(
+    request: pytest.FixtureRequest,
+) -> AirPurifierDriver:
     """Return a mocked AirPurifierDriver instance."""
 
     json_value = {"body": {"data": [{"attributes": request.param}]}}
@@ -124,7 +127,9 @@ def mock_dehumidifier_driver() -> DehumidifierDriver:
 
 
 @pytest.fixture
-def mock_dehumidifier_driver_with_payload(request: pytest.FixtureRequest) -> DehumidifierDriver:
+def mock_dehumidifier_driver_with_payload(
+    request: pytest.FixtureRequest,
+) -> DehumidifierDriver:
     """Return a mocked DehumidifierDriver instance with preset payload."""
 
     json_value = {"body": {"data": [{"attributes": request.param}]}}

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,9 +1,13 @@
 """Test Winixdevice component."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.winix.const import (
     AIRFLOW_HIGH,
@@ -19,10 +23,15 @@ from custom_components.winix.const import (
     SERVICE_PLASMAWAVE_ON,
     WINIX_DOMAIN,
 )
-from custom_components.winix.fan import WinixPurifier, async_setup_entry
+from custom_components.winix.fan import (
+    FAN_ON_OFF_REFRESH_DELAY,
+    WinixPurifier,
+    async_setup_entry,
+)
 from homeassistant.components.fan import FanEntityFeature
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .common import build_fake_manager, build_purifier  # noqa: TID251
 
@@ -240,6 +249,24 @@ async def test_async_set_percentage_non_zero(
     assert mock_device_wrapper.async_set_speed.call_count == 1
 
 
+async def test_async_turn_off(hass: HomeAssistant, mock_device_wrapper) -> None:
+    """Test turning off."""
+
+    device = build_purifier(hass, mock_device_wrapper)
+    device.async_set_percentage = AsyncMock()
+
+    await device.async_turn_off()
+    assert device.async_set_percentage.call_count == 0
+    assert mock_device_wrapper.async_set_preset_mode.call_count == 0
+    assert mock_device_wrapper.async_turn_off.call_count == 1
+
+    future = dt_util.utcnow() + timedelta(seconds=FAN_ON_OFF_REFRESH_DELAY)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    assert device.coordinator.async_request_refresh.call_count == 1
+
+
 async def test_async_turn_on(hass: HomeAssistant, mock_device_wrapper) -> None:
     """Test turning on."""
 
@@ -250,6 +277,12 @@ async def test_async_turn_on(hass: HomeAssistant, mock_device_wrapper) -> None:
     assert device.async_set_percentage.call_count == 0
     assert mock_device_wrapper.async_set_preset_mode.call_count == 0
     assert mock_device_wrapper.async_turn_on.call_count == 1
+
+    future = dt_util.utcnow() + timedelta(seconds=FAN_ON_OFF_REFRESH_DELAY)
+    async_fire_time_changed(hass, future)
+    await hass.async_block_till_done()
+
+    assert device.coordinator.async_request_refresh.call_count == 1
 
 
 async def test_async_turn_on_percentage(


### PR DESCRIPTION
Refreshing data after turning fan on/off causes stale data to be returned, the next refresh does bring in correct status.
This leads to the on/off switch momentarily toggling to incorrect state.

The refresh is done to update other entities which are dependent on on/off state and are controlled the remote end point.

Delaying the refresh by 4 second delay seems to bring in correct data.