### PR TITLE
Add Tower Prime APRM833-JWK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A custom component to interact with Winix air purifiers and dehumidifiers.
 
-Air purifiers: confirmed on [C545](https://www.winixamerica.com/product/certified-refurbished-c545-air-purifier/) and [C610](https://www.winixamerica.com/product/c610/), and reported to work on [AM90](https://www.winixamerica.com/product/am90/), [HR1000](https://www.amazon.com/Winix-HR1000-5-Stage-Enabled-Cleaner/dp/B01FWS0HSY), [C909](https://www.costco.com/winix-c909-4-stage-air-purifier-with-wi-fi-%2526-plasmawave-technology.product.100842491.html), [T800](https://winixeurope.eu/air-purifiers/winix-t800-wifi/), [T810](https://www.winixamerica.com/product/t810/), [5510](http://winixamerica.com/product/5510/), [5520](http://winixamerica.com/product/5520/), [9800](https://www.winixamerica.com/product/9800/), [T500](https://www.winixamerica.com/product/t500/) — functionality may vary by model. 
+Air purifiers: confirmed on [C545](https://www.winixamerica.com/product/certified-refurbished-c545-air-purifier/), [C610](https://www.winixamerica.com/product/c610/), and [Tower Prime APRM833-JWK](https://www.winix.com/product/1211); reported to work on [AM90](https://www.winixamerica.com/product/am90/), [HR1000](https://www.amazon.com/Winix-HR1000-5-Stage-Enabled-Cleaner/dp/B01FWS0HSY), [C909](https://www.costco.com/winix-c909-4-stage-air-purifier-with-wi-fi-%2526-plasmawave-technology.product.100842491.html), [T800](https://winixeurope.eu/air-purifiers/winix-t800-wifi/), [T810](https://www.winixamerica.com/product/t810/), [5510](http://winixamerica.com/product/5510/), [5520](http://winixamerica.com/product/5520/), [9800](https://www.winixamerica.com/product/9800/), [T500](https://www.winixamerica.com/product/t500/)…
 Dehumidifiers: confirmed on [DXWE210](https://www.winix.com/product/1689) (Korean page). Other models in the `DXW*21*` family are likely compatible.
 
 ## Installation
@@ -31,6 +31,7 @@ This can be installed by copying all the files from `custom_components/winix/` t
   - Poor (Red) = 3
 - The `Filter Life` sensor represents the left filter life and is based on an initial life of 9 months.
 - The `PM 2.5` sensor is exposed only on devices that report particulate readings (e.g., T800).
+- Tower Prime APRM833-JWK exposes its Super Clean mode as the highest fan-speed percentage.
 
 - The fan entity supports speed and preset modes
 - The `Child Lock` switch toggles the device's child lock, exposed only on devices that report support for the feature.

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -49,6 +49,7 @@ AUTO_DRY_VALUE: Final = "auto-dry"
 AIR_QUALITY_GOOD: Final = "good"
 AIR_QUALITY_FAIR: Final = "fair"
 AIR_QUALITY_POOR: Final = "poor"
+AIR_QUALITY_VERY_POOR: Final = "very_poor"
 
 # The service name is the partial name of the method in WinixPurifier
 SERVICE_PLASMAWAVE_ON: Final = "plasmawave_on"

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -1,7 +1,7 @@
 """Constants for the Winix component."""
 
-from enum import StrEnum, unique
 import logging
+from enum import StrEnum, unique
 from typing import Final
 
 __min_ha_version__ = "2024.8"
@@ -68,12 +68,19 @@ AIRFLOW_MEDIUM: Final = "medium"
 AIRFLOW_HIGH: Final = "high"
 AIRFLOW_TURBO: Final = "turbo"
 AIRFLOW_SLEEP: Final = "sleep"
+AIRFLOW_SUPER: Final = "super"
 
 ORDERED_NAMED_FAN_SPEEDS: Final = [
     AIRFLOW_LOW,
     AIRFLOW_MEDIUM,
     AIRFLOW_HIGH,
     AIRFLOW_TURBO,
+]
+
+TOWER_PRIME_MODEL: Final = "TOWER PRIME"
+ORDERED_NAMED_TOWER_PRIME_FAN_SPEEDS: Final = [
+    *ORDERED_NAMED_FAN_SPEEDS,
+    AIRFLOW_SUPER,
 ]
 
 DEHUMIDIFIER_FAN_SPEEDS: Final = [

--- a/custom_components/winix/const.py
+++ b/custom_components/winix/const.py
@@ -1,7 +1,7 @@
 """Constants for the Winix component."""
 
-import logging
 from enum import StrEnum, unique
+import logging
 from typing import Final
 
 __min_ha_version__ = "2024.8"

--- a/custom_components/winix/device_wrapper.py
+++ b/custom_components/winix/device_wrapper.py
@@ -22,12 +22,15 @@ from .const import (
     MODE_MANUAL,
     OFF_VALUE,
     ON_VALUE,
+    ORDERED_NAMED_FAN_SPEEDS,
+    ORDERED_NAMED_TOWER_PRIME_FAN_SPEEDS,
     PRESET_MODE_AUTO,
     PRESET_MODE_AUTO_PLASMA_OFF,
     PRESET_MODE_MANUAL,
     PRESET_MODE_MANUAL_PLASMA_OFF,
     PRESET_MODE_SLEEP,
     PRESET_MODES,
+    TOWER_PRIME_MODEL,
     Features,
     NumericPresetModes,
 )
@@ -182,6 +185,13 @@ class WinixDeviceWrapper:
     def features(self) -> Features:
         """Return device features."""
         return self._features
+
+    @property
+    def fan_speeds(self) -> list[str]:
+        """Return fan speeds supported by this purifier model."""
+        if (self.device_stub.model or "").casefold() == TOWER_PRIME_MODEL.casefold():
+            return ORDERED_NAMED_TOWER_PRIME_FAN_SPEEDS
+        return ORDERED_NAMED_FAN_SPEEDS
 
     @property
     def is_air_purifier(self) -> bool:

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -3,7 +3,6 @@
 from enum import Enum, unique
 
 import aiohttp
-
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
@@ -14,6 +13,7 @@ from .const import (
     AIRFLOW_LOW,
     AIRFLOW_MEDIUM,
     AIRFLOW_SLEEP,
+    AIRFLOW_SUPER,
     AIRFLOW_TURBO,
     ATTR_AIR_AQI,
     ATTR_AIR_QUALITY,
@@ -217,6 +217,7 @@ class AirPurifierDriver(WinixDriver):
             AIRFLOW_HIGH: "03",
             AIRFLOW_TURBO: "05",
             AIRFLOW_SLEEP: "06",
+            AIRFLOW_SUPER: "08",
         },
         ATTR_CHILD_LOCK: {OFF_VALUE: "0", ON_VALUE: "1"},
         ATTR_PLASMA: {OFF_VALUE: "0", ON_VALUE: "1"},
@@ -282,6 +283,10 @@ class AirPurifierDriver(WinixDriver):
     async def turbo(self) -> None:
         """Set speed turbo."""
         await self.control(ATTR_AIRFLOW, AIRFLOW_TURBO)
+
+    async def super(self) -> None:
+        """Set speed to Super Clean."""
+        await self.control(ATTR_AIRFLOW, AIRFLOW_SUPER)
 
     async def sleep(self) -> None:
         """Set device in sleep mode."""

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -3,6 +3,7 @@
 from enum import Enum, unique
 
 import aiohttp
+
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import (

--- a/custom_components/winix/driver.py
+++ b/custom_components/winix/driver.py
@@ -9,6 +9,7 @@ from .const import (
     AIR_QUALITY_FAIR,
     AIR_QUALITY_GOOD,
     AIR_QUALITY_POOR,
+    AIR_QUALITY_VERY_POOR,
     AIRFLOW_HIGH,
     AIRFLOW_LOW,
     AIRFLOW_MEDIUM,
@@ -225,6 +226,7 @@ class AirPurifierDriver(WinixDriver):
             AIR_QUALITY_GOOD: "01",
             AIR_QUALITY_FAIR: "02",
             AIR_QUALITY_POOR: "03",
+            AIR_QUALITY_VERY_POOR: "04",
         },
     }
 

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -5,11 +5,12 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
-import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+
 from homeassistant.components.fan import ENTITY_ID_FORMAT, FanEntity, FanEntityFeature
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HassJob, HomeAssistant
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.percentage import (

--- a/custom_components/winix/fan.py
+++ b/custom_components/winix/fan.py
@@ -5,12 +5,11 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
+import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-
 from homeassistant.components.fan import ENTITY_ID_FORMAT, FanEntity, FanEntityFeature
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HassJob, HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.percentage import (
@@ -27,7 +26,6 @@ from .const import (
     ATTR_POWER,
     FAN_SERVICES,
     LOGGER,
-    ORDERED_NAMED_FAN_SPEEDS,
     PRESET_MODE_AUTO,
     PRESET_MODE_AUTO_PLASMA_OFF,
     PRESET_MODE_MANUAL,
@@ -168,9 +166,8 @@ class WinixPurifier(WinixEntity, FanEntity):
         if state.get(ATTR_AIRFLOW) is None:
             return None
 
-        return ordered_list_item_to_percentage(
-            ORDERED_NAMED_FAN_SPEEDS, state.get(ATTR_AIRFLOW)
-        )
+        fan_speeds = self.device_wrapper.fan_speeds
+        return ordered_list_item_to_percentage(fan_speeds, state.get(ATTR_AIRFLOW))
 
     @property
     def preset_mode(self) -> str | None:
@@ -203,12 +200,12 @@ class WinixPurifier(WinixEntity, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return ORDERED_NAMED_FAN_SPEEDS
+        return self.device_wrapper.fan_speeds
 
     @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
-        return len(ORDERED_NAMED_FAN_SPEEDS)
+        return len(self.device_wrapper.fan_speeds)
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -216,7 +213,9 @@ class WinixPurifier(WinixEntity, FanEntity):
             await self.async_turn_off()
         else:
             await self.device_wrapper.async_set_speed(
-                percentage_to_ordered_list_item(ORDERED_NAMED_FAN_SPEEDS, percentage)
+                percentage_to_ordered_list_item(
+                    self.device_wrapper.fan_speeds, percentage
+                )
             )
 
         self.async_write_ha_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
+from custom_components.winix.const import ORDERED_NAMED_FAN_SPEEDS
 from custom_components.winix.device_wrapper import WinixDeviceWrapper
 from custom_components.winix.driver import AirPurifierDriver, DehumidifierDriver
 from custom_components.winix.stub import MyWinixDeviceStub
@@ -77,6 +78,7 @@ def mock_device_wrapper() -> WinixDeviceWrapper:
     device_wrapper = MagicMock()
     device_wrapper.device_stub.mac = "f190d35456d0"
     device_wrapper.device_stub.alias = "Purifier1"
+    device_wrapper.fan_speeds = ORDERED_NAMED_FAN_SPEEDS
 
     device_wrapper.async_plasmawave_off = AsyncMock()
     device_wrapper.async_plasmawave_on = AsyncMock()

--- a/tests/test_device_wrapper.py
+++ b/tests/test_device_wrapper.py
@@ -21,6 +21,8 @@ from custom_components.winix.const import (
     MODE_MANUAL,
     OFF_VALUE,
     ON_VALUE,
+    ORDERED_NAMED_FAN_SPEEDS,
+    ORDERED_NAMED_TOWER_PRIME_FAN_SPEEDS,
     PRESET_MODE_AUTO,
     PRESET_MODE_AUTO_PLASMA_OFF,
     PRESET_MODE_MANUAL,
@@ -99,6 +101,21 @@ async def test_wrapper_update(
         assert wrapper.is_on == is_on
         assert wrapper.is_plasma_on == is_plasma_on
         assert wrapper.is_sleep == is_sleep
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("C545", ORDERED_NAMED_FAN_SPEEDS),
+        ("TOWER PRIME", ORDERED_NAMED_TOWER_PRIME_FAN_SPEEDS),
+    ],
+)
+def test_model_fan_speeds(model, expected) -> None:
+    """Expose Super Clean only for Tower Prime."""
+    wrapper = build_mock_wrapper()
+    wrapper.device_stub.model = model
+
+    assert wrapper.fan_speeds == expected
 
 
 async def test_async_ensure_on() -> None:

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -48,6 +48,7 @@ async def test_turn_off(mock_rpc_attr, mock_airpurifier_driver, method, category
         ({"S08": "79"}, {"air_qvalue": 79}),  # air_qvalue
         ({"S04": "12"}, {"pm2_5": 12}),  # pm2_5
         ({"A04": "08"}, {"airflow": "super"}),
+        ({"S07": "04"}, {"air_quality": "very_poor"}),
     ],
     indirect=["mock_airpurifier_driver_with_payload"],
 )

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -26,6 +26,7 @@ from custom_components.winix.driver import AirPurifierDriver, DehumidifierDriver
         ("high", "airflow", "high"),
         ("turbo", "airflow", "turbo"),
         ("sleep", "airflow", "sleep"),
+        ("super", "airflow", "super"),
     ],
 )
 async def test_turn_off(mock_rpc_attr, mock_airpurifier_driver, method, category, value) -> None:
@@ -46,6 +47,7 @@ async def test_turn_off(mock_rpc_attr, mock_airpurifier_driver, method, category
         ({"A02": "1"}, {"power": "on"}),
         ({"S08": "79"}, {"air_qvalue": 79}),  # air_qvalue
         ({"S04": "12"}, {"pm2_5": 12}),  # pm2_5
+        ({"A04": "08"}, {"airflow": "super"}),
     ],
     indirect=["mock_airpurifier_driver_with_payload"],
 )

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -4,6 +4,10 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from homeassistant.components.fan import FanEntityFeature
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
@@ -12,8 +16,10 @@ from pytest_homeassistant_custom_component.common import (
 from custom_components.winix.const import (
     AIRFLOW_HIGH,
     AIRFLOW_LOW,
+    AIRFLOW_SUPER,
     ATTR_AIRFLOW,
     ORDERED_NAMED_FAN_SPEEDS,
+    ORDERED_NAMED_TOWER_PRIME_FAN_SPEEDS,
     PRESET_MODE_AUTO,
     PRESET_MODE_AUTO_PLASMA_OFF,
     PRESET_MODE_MANUAL,
@@ -28,10 +34,6 @@ from custom_components.winix.fan import (
     WinixPurifier,
     async_setup_entry,
 )
-from homeassistant.components.fan import FanEntityFeature
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
 
 from .common import build_fake_manager, build_purifier  # noqa: TID251
 
@@ -112,6 +114,7 @@ def test_construction(hass: HomeAssistant) -> None:
     """Test device construction."""
     device_wrapper = Mock()
     device_wrapper.get_state = Mock(return_value={})
+    device_wrapper.fan_speeds = ORDERED_NAMED_FAN_SPEEDS
 
     device = WinixPurifier(device_wrapper, Mock())
     assert device.unique_id is not None
@@ -182,6 +185,7 @@ def test_device_percentage(state, is_sleep, is_auto, expected) -> None:
     device_wrapper = Mock()
     type(device_wrapper).is_sleep = is_sleep
     type(device_wrapper).is_auto = is_auto
+    device_wrapper.fan_speeds = ORDERED_NAMED_FAN_SPEEDS
     device_wrapper.get_state = Mock(return_value=state)
     device = WinixPurifier(device_wrapper, Mock())
     assert device.percentage is expected
@@ -247,6 +251,18 @@ async def test_async_set_percentage_non_zero(
     await device.async_set_percentage(20)
     assert device.async_turn_off.call_count == 0
     assert mock_device_wrapper.async_set_speed.call_count == 1
+
+
+async def test_async_set_percentage_tower_prime(
+    hass: HomeAssistant, mock_device_wrapper
+) -> None:
+    """Map Tower Prime's maximum percentage to Super Clean."""
+    mock_device_wrapper.fan_speeds = ORDERED_NAMED_TOWER_PRIME_FAN_SPEEDS
+    device = build_purifier(hass, mock_device_wrapper)
+
+    await device.async_set_percentage(100)
+
+    mock_device_wrapper.async_set_speed.assert_called_once_with(AIRFLOW_SUPER)
 
 
 async def test_async_turn_off(hass: HomeAssistant, mock_device_wrapper) -> None:

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -4,10 +4,6 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from homeassistant.components.fan import FanEntityFeature
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
@@ -34,6 +30,10 @@ from custom_components.winix.fan import (
     WinixPurifier,
     async_setup_entry,
 )
+from homeassistant.components.fan import FanEntityFeature
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .common import build_fake_manager, build_purifier  # noqa: TID251
 


### PR DESCRIPTION
## Summary
- add Tower Prime-specific Super Clean airflow support (`A04=08`)
- expose five fan-speed steps only for the `TOWER PRIME` API model
- parse the fourth air-quality level (`S07=04`) as very poor
- document APRM833-JWK as a confirmed model

## Commits
1. `feat: support Tower Prime Super Clean mode`
2. `fix: parse very poor air quality state`
3. `style: organize imports with Home Assistant Ruff config`

The branch is rebased onto the current upstream `main`.

## Verification
- reverse-engineered Winix Smart 1.5.8 model metadata: `PRIME` / `PRIMEKOR` / `Air04`
- verified against an APRM833-JWK: Super Clean control returned `S100` and state changed to `A04=08`
- verified PlasmaWave `A07` control and restored the original device state
- Home Assistant live smoke test reports `percentage_step=20.0`
- `200 passed` on Python 3.14 (`pytest tests/ -p asyncio --asyncio-mode=auto -q`)
- Home Assistant Core Ruff import configuration passes (`ruff check . --select I` with the HA isort settings)
