### PR TITLE
fix: use correct unit

### DIFF
--- a/custom_components/winix/sensor.py
+++ b/custom_components/winix/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfDensity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -115,7 +115,7 @@ SENSOR_DESCRIPTIONS: tuple[WinixSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.PM25,
         key=SENSOR_PM25,
         translation_key="pm2_5",
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         value_fn=lambda state, wrapper: state.get(ATTR_PM25),
         exists_fn=lambda device: (
             device.is_air_purifier and device.features.supports_pm25


### PR DESCRIPTION
Use UnitOfDensity.MICROGRAMS_PER_CUBIC_METER instead of CONCENTRATION_MICROGRAMS_PER_CUBIC_METER which has been flagged to be deprecated in 2027.8.

Closes #181